### PR TITLE
Add jekyll and lyx ignore rules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 ImportTestData
+.bundle/
+.jekyll-cache/
+Gemfile
+Gemfile.lock
+_site/
+vendor/
+*.lyx~


### PR DESCRIPTION
Changes proposed in this pull request:
Update gitignore so that it ignores
- Jekyll related files
- lyx swap files (`.lyx~`)
