### PR TITLE
Issue #39 pspm_version.m solution for the bug

### DIFF
--- a/src/pspm_version.m
+++ b/src/pspm_version.m
@@ -39,8 +39,8 @@ v = tk{v_idx}{1}{1};
 if nargin > 0
     switch varargin{1}
         case 'check' % check for updates
-            [str, status] = urlread('http://pspm.sourceforge.net/');
-            if status == 1
+            try
+                str = webread('http://pspm.sourceforge.net/');
                 begidx = strfind(str, 'Current version');
                 endidx = begidx + strfind(str(begidx : end), sprintf('\n'));
                 endidx = endidx(1);
@@ -77,7 +77,7 @@ if nargin > 0
                 else
                     warning('ID:invalid_input', 'Cannot figure out if there is a new version.'); return;
                 end
-            else
+            catch
                 warning('ID:invalid_input', 'Cannot check for updates.'); return
             end
     end


### PR DESCRIPTION
Fixes #39 .

Changes proposed in this pull request:
- Fixed the problem using `webread` function and `try ... catch ... end` method.
- Works with `-nojvm -nodesktop -nobatch` .
- In case of error with url reading, the warning is still sent.
