### PR TITLE
Make sure there is a + marker in sess begin markers in import_viewpoint

### DIFF
--- a/src/Import/viewpoint/import_viewpoint.m
+++ b/src/Import/viewpoint/import_viewpoint.m
@@ -54,7 +54,7 @@ function [data] = import_viewpoint(filepath)
         idx = marker_indices(i);
         marker_str = marker{idx};
         char_eq = (marker_str == '+') + (marker_str == '=') + (marker_str == ',');
-        if sum(char_eq) == numel(marker_str)
+        if sum(char_eq) == numel(marker_str) && sum(marker_str == '+') > 0
             sess_beg_indices(end + 1) = idx;
         end
     end


### PR DESCRIPTION
Changes proposed in this pull request:
- Although in #53 we fixed the session begin index definition, we forgot a case: if a marker doesn't contain a `+` marker, it cannot be counted as a session begin marker. This pull request fixes this issue
