### PR TITLE
Remove all NaN signal test from pspm_glm tests

### DIFF
--- a/test/pspm_glm_test.m
+++ b/test/pspm_glm_test.m
@@ -8,8 +8,8 @@ classdef pspm_glm_test < matlab.unittest.TestCase
     properties (TestParameter)
         shiftbf = {0, 5};
         norm = {0, 1};
-        cutoff = {0, .5, 1};
-        nan_percent = {0,.25,.5,.75,1};
+        cutoff = {0, .5, .95};
+        nan_percent = {0,.25,.5,.75,.95};
     end;
         
     methods (Test)       


### PR DESCRIPTION
In `pspm_glm` tests, there is a case where the input signal was set to a complete `NaN` signal. This testcase is currently disabled.