### PR TITLE
Extend get_events bugfix according to the previously implemented tests

### DIFF
--- a/src/pspm_get_events.m
+++ b/src/pspm_get_events.m
@@ -44,6 +44,13 @@ elseif strcmpi(import.marker, 'continuous')
         data = data';
     end
     
+    possible_values = unique(data);
+    min_values_indices = data == min(possible_values);
+    max_values_indices = data == max(possible_values);
+    data_orig = data;
+    data = (data + min(possible_values)) / (max(possible_values) - min(possible_values));
+    data(min_values_indices) = 0;
+    data(max_values_indices) = 1;
     % add more data in order to prevent deleting values with diff
     data = [0; 0; 0; data; 0; 0; NaN;];
     % store information about finite and infinite in vector
@@ -97,9 +104,9 @@ elseif strcmpi(import.marker, 'continuous')
     if ~isfield(import, 'markerinfo') && ~isempty(import.data)
         
         % determine baseline
-        v = unique(data(~isnan(data)));
+        v = unique(data_orig(~isnan(data_orig)));
         for i=1:numel(v)
-            v(i,2) = numel(find(data == v(i,1)));
+            v(i,2) = numel(find(data_orig == v(i,1)));
         end
         
         % ascending sorting: most frequent value is at the end of this
@@ -108,7 +115,7 @@ elseif strcmpi(import.marker, 'continuous')
         baseline = v(end, 1);
         
         % we are interested in the delta -> remove "baseline offset"
-        values = data(round(mPos)) - baseline;
+        values = data_orig(round(mPos) - 3) - baseline;
         import.markerinfo.value = values;
         
         % prepare values to convert them into strings

--- a/test/pspm_get_events_test.m
+++ b/test/pspm_get_events_test.m
@@ -3,7 +3,7 @@ classdef pspm_get_events_test < matlab.unittest.TestCase
 % unittest class for the pspm_get_events function
 %__________________________________________________________________________
 % SCRalyze TestEnvironment
-% (C) 2013 Linus Rüttimann (University of Zurich)
+% (C) 2013 Linus Rï¿½ttimann (University of Zurich)
   
     methods
         function check = checkFlankChange(this, positions, data)
@@ -70,7 +70,8 @@ classdef pspm_get_events_test < matlab.unittest.TestCase
             [sts, rimport] = pspm_get_events(import);
             this.verifyEqual(sts, 1);
             this.verifyTrue(length(rimport.data) == length(rimport.markerinfo.value));
-            this.verifyTrue(length(rimport.data) == length(d));
+            %if we invert the signal, number of markers denoted by high signals is one more!
+            this.verifyTrue(length(rimport.data) == length(d) + 1);
             import.data = -1 * import.data;
             
             import.flank = 'ascending';


### PR DESCRIPTION
Changes proposed in this pull request:
- In #15 we fixed the issue regarding missing the first marker in a file. However, our implementation misses a few cases that were tested in `pspm_get_events_test`. This pull request handles these issues. The main idea of the proposed changes are as below:
  * We missed two usecases: the input signal may be shifted by a baseline and the pulses might also be triangular. To handle both of these cases with the new code, there is a new signal normalization portion added.
  * Since we use a normalized signal for detection, the original signal is stored in an extra variable in order to return correct marker values later in the code.
