### PR TITLE
Changed the url in pspm_version.m

### DIFF
--- a/src/pspm_version.m
+++ b/src/pspm_version.m
@@ -40,7 +40,7 @@ if nargin > 0
     switch varargin{1}
         case 'check' % check for updates
             try
-                str = webread('http://pspm.sourceforge.net/');
+                str = webread('https://bachlab.github.io/PsPM/');
                 begidx = strfind(str, 'Current version');
                 endidx = begidx + strfind(str(begidx : end), sprintf('\n'));
                 endidx = endidx(1);


### PR DESCRIPTION
Fixes #40 .

Changes proposed in this pull request:
- I've just changed the url in `pspm_version.m` file and it works due to the fact that `https://bachlab.github.io/PsPM/`.
