### PR TITLE
Fix/issue67 : New procedure for catching markers in an Eyelink file

### DIFF
--- a/src/Import/eyelink/import_eyelink.m
+++ b/src/Import/eyelink/import_eyelink.m
@@ -299,9 +299,11 @@ function [dataraw, markers, chan_info] = parse_messages(messages, dataraw, chan_
         msgline = messages{idx};
         parts = split(msgline);
         time = str2num(parts{2});
-        markers.markers(bsearch(timecol, time)) = true;
-        markers.times(end + 1, 1) = time;
-        markers.names{end + 1, 1} = cell2mat(join(parts(3:end), ' '));
+        if time < session_end_time
+            markers.markers(bsearch(timecol, time)) = true;
+            markers.times(end + 1, 1) = time;
+            markers.names{end + 1, 1} = cell2mat(join(parts(3:end), ' '));
+        end
     end
 
     % set data columns

--- a/src/Import/eyelink/import_eyelink.m
+++ b/src/Import/eyelink/import_eyelink.m
@@ -299,7 +299,7 @@ function [dataraw, markers, chan_info] = parse_messages(messages, dataraw, chan_
         msgline = messages{idx};
         parts = split(msgline);
         time = str2num(parts{2});
-        if time < session_end_time
+        if time <= session_end_time
             markers.markers(bsearch(timecol, time)) = true;
             markers.times(end + 1, 1) = time;
             markers.names{end + 1, 1} = cell2mat(join(parts(3:end), ' '));

--- a/src/pspm_get_events.m
+++ b/src/pspm_get_events.m
@@ -6,7 +6,7 @@ function [sts, import] = pspm_get_events(import)
 %                  .marker ('timestamps', 'continuous')
 %                  .sr (timestamps: timeunits in seconds, continuous: sample rate in 1/seconds)
 %                  and optional field
-%                  .flank ('ascending', 'descending', 'both': optional field for
+%                  .flank ('ascending', 'descending', 'both', 'all': optional field for
 %                   continuous channels; default: both)
 %           returns event timestamps in seconds in import.data
 %__________________________________________________________________________
@@ -81,6 +81,10 @@ elseif strcmpi(import.marker, 'continuous')
         fprintf('\n');
         warning('No markers, or problem with TTL channel.');
         import.data = [];
+    elseif isfield(import,'flank') && strcmpi(import.flank, 'all')
+        allMrk = find(import.data);
+        import.data = allMrk./import.sr;
+        mPos = allMrk+3;
     elseif isfield(import, 'flank') && strcmpi(import.flank, 'ascending')
         import.data = lo2hi./import.sr; 
         mPos = lo2hi+3; 

--- a/src/pspm_get_eyelink.m
+++ b/src/pspm_get_eyelink.m
@@ -257,8 +257,8 @@ function [sts, import, sourceinfo] = pspm_get_eyelink(datafile, import)
             % imported data cannot be read at the moment (in later instances)
             import{k}.markerinfo = markerinfos;
 
-            % use ascending flank for translation from continuous to events
-            import{k}.flank = 'ascending';
+            % use 'all' flank for translation from continuous to events
+            import{k}.flank = 'all';
         else    
             % determine chan id from chantype - eyelink specific
             % thats why channel ids will be ignored!


### PR DESCRIPTION
Fixes #67 .

Changes proposed in this pull request (per file):
1. `import_eyelink.m` : 
     - implement a condition that does not allow us to import markers which are outside the session end time (i.e. the last timestamp before the marker `END`)
2. `pspm_get_events.m` :
     - added a new `import.flank` parameter called `'all'` which imports all markers and data related to them.
     - `pspm_get_eyelink` function calls `pspm_get_events` in order to transform the original continuous markers data to an vector of "events", but when it encounter data such as the following one it will consider consecutive markers as one continuous one and thus with the option `ascending` it will catch the timestamp only of the first one.
```
------ Raw Eyelink data -------    ------ Data that pspm_get_events receives -------
6084232	   .	   .	    0.0            6084232        0
6084233	   .	   .	    0.0            6084233        0
6084234	   .	   .	    0.0            6084234        0
MSG	6084235 Start End                  6084235        1
6084235	   .	   .	    0.0                                                           
MSG	6084236 JitterFix                  6084236        1
6084236	   .	   .	    0.0                                                        
6084237	   .	   .	    0.0            6084237        0
6084238	   .	   .	    0.0            6084238        0
6084239	   .	   .	    0.0            6084239        0
```
3. `pspm_get_eyelink.m` :
     - I have changed the `import.flank` parameter to `'all'` for eyelink files according to the changes from point 2.
