### PR TITLE
Added a warning in the tutorial about the toolbox.

### DIFF
--- a/doc/PsPM_Manual.lyx
+++ b/doc/PsPM_Manual.lyx
@@ -13606,6 +13606,8 @@ literal "true"
  that included two short breaks.
  SCR data were recorded using a 0.5 V coupler, optical (wave to pulse) transducer
 , and CED Spike, with a minimum sampling rate of 100 Hz.
+ Be aware that this example uses functions from the MATLAB Signal Processing
+ Toolbox, make sure to have it installed before starting the tutorial.
 \end_layout
 
 \begin_layout Subsection


### PR DESCRIPTION
Fixes #80  .

Changes proposed in this pull request:
- Added a warning in the tutorial to inform users that the Signal Processing Toolbox is needed for the tutorial. (Dominik's request)

I don't know who is responsible for publishing tutorial data, that's why I haven't done.