### PR TITLE
Issue/yanfang

### DIFF
--- a/src/pspm_bf_spsrf_box.m
+++ b/src/pspm_bf_spsrf_box.m
@@ -17,7 +17,7 @@ if nargin < 1
 end;
 
 if nargin < 2
-    soa = 3.5;
+    soa = 3;
 end;
 
 

--- a/src/pspm_bf_spsrf_box.m
+++ b/src/pspm_bf_spsrf_box.m
@@ -1,4 +1,4 @@
-function [bs, x] = pspm_bf_spsrf_box( td, soa )
+function [bs, x] = pspm_bf_spsrf_box(td, soa)
 % pspm_bf_spsrf_box basis function dependent on SOA 
 
 % FORMAT: [bf p] = pspm_bf_spsrf_box(td, soa)
@@ -23,8 +23,8 @@ end;
 
 %create boder of interval
 stop = soa;
-start = soa-2;
-start_idx = floor(start/td);
+start = soa - 2;
+start_idx = floor(start/td)+1;
 if start_idx ==0
     start_idx = start_idx+1;
 end 

--- a/src/pspm_bf_spsrf_box.m
+++ b/src/pspm_bf_spsrf_box.m
@@ -1,6 +1,9 @@
-function [bs, x] = pspm_bf_spsrf_box(td, soa)
+function [bs, x] = pspm_bf_spsrf_box(varargin)
 % pspm_bf_spsrf_box basis function dependent on SOA 
-
+%
+% FORMAT: [bs, x] = pspm_bf_spsrf_box(td, soa) 
+%     OR: [bs, x] = pspm_bf_spsrf_box([td, soa])
+%
 % FORMAT: [bf p] = pspm_bf_spsrf_box(td, soa)
 %         with  td: time resolution in s
 %
@@ -12,12 +15,15 @@ global settings
 if isempty(settings), pspm_init; end;
 
 % check input arguments
-if nargin < 1
-   errmsg='No sampling interval stated'; warning('ID:invalid_input',errmsg); return;
-end;
-
-if nargin < 2
-    soa = 3;
+if nargin==0
+    errmsg='No sampling interval stated'; warning('ID:invalid_input', errmsg); return;
+elseif nargin == 1
+    n_el = numel(varargin{1});
+    td = varargin{1}(1);
+    if n_el > 1, soa = varargin{1}(2); else , soa=3.5; end;
+elseif nargin > 1
+    td = varargin{1};
+    soa = varargin{2};
 end;
 
 

--- a/src/pspm_bf_spsrf_gamma.m
+++ b/src/pspm_bf_spsrf_gamma.m
@@ -1,5 +1,6 @@
 function [bs, t] = pspm_bf_spsrf_gamma(varargin)
-% pspm_bf_spsrf_box basis 
+% pspm_bf_spsrf_box basis function with a total duration of 10 seconds
+% and a shift of (SOA-3) seconds (see reference).
 % 
 %   FORMAT: [bf p] = pspm_bf_spsrf_gamma(td,soa,p) OR
 %           [bf p] = pspm_bf_spsrf_gamma([td,soa,p])
@@ -23,45 +24,55 @@ elseif nargin == 1
     n_el = numel(varargin{1});
     td = varargin{1}(1);
     if n_el > 1, soa = varargin{1}(2); else , soa=3.5; end;
+    if n_el > 2, p = varargin{1}(3:end); else , p = NaN; end;
 elseif nargin > 1
     td = varargin{1};
     soa = varargin{2};
-    if nargin > 2 
-        p = varargin{3};
-        errmsg = 'Basis function parameter must be a numeric vector with 4 elements.'
-        if ~isnumeric(p) || numel(p)~=4, warning('ID:invalid_input', errmsg); return; end;
-    else
-        % parameters obtained by fitting a gamma function to smoothed test data
-        p = [-0.00953999201164847,-1.90202591900308,10.0912982464000,0.421253777432825];
-    end;
+    if nargin > 2, p = varargin{3}; else , p=NaN; end;
 end;
 
+% Check td
+if td > 10
+    warning('ID:invalid_input', 'Time resolution is larger than duration of the function.'); return;
+end;
+
+% Check soa
+if ~isnumeric(soa)
+    warning('The SOA should be a numeric value.'); return;
+elseif soa < 3
+    soa = 3;
+    warning('Changing SOA to 3s to avoid implausible values (<3s).');
+elseif soa > 7
+     warning(['SOA longer than 7s is not recommended. Use at own risk.']);
+end;
+    
+% Check p
+if ~isnan(p) 
+    p = varargin{3};
+    errmsg = 'Basis function parameter must be a numeric vector with 4 elements.';
+    if ~isnumeric(p) || numel(p)~=4, warning('ID:invalid_input', errmsg); return; end;
+else
+    % parameters obtained by fitting a gamma function to smoothed test data
+    p = [-0.00953999201164847,-1.90202591900308,10.0912982464000,0.421253777432825];
+end;
+
+% Computation of bs
 A  = p(1);
 x0 = p(2);
 a  = p(3);
 b  = p(4);
 
-% default value
-d     = 10;
 start = 0;
-stop  = d + soa;
+stop  = 10;  % duration of bs 10s by default
 
-if td > (stop-start)
-    warning('ID:invalid_input', 'Time resolution is larger than duration of the function.'); return;
-elseif td == 0
-    warning('ID:invalid_input', 'Time resolution must be larger than 0.'); return;
-elseif soa < 2
-    soa = 2;
-    stop = d + soa;
-    warning('Changing SOA to 2s to avoid implausible values (<2s).');
-elseif soa > 8
-    warning(['SOA longer than 8s is not recommended. ', ...
-        'Use at own risk.']);
-end;
-
-shift = soa + x0;
+shift = x0 + (soa - 3);
 
 t = (start:td:stop-td)';
+
 bs = A * gampdf(t - shift, a, b);
+
+bs = bs/max(bs); % Normalizing by the max value
+bs = bs./repmat((max(bs) - min(bs)), size(bs, 1), 1); % making it between [0,1]
+
 end
 

--- a/src/pspm_bf_spsrf_gamma.m
+++ b/src/pspm_bf_spsrf_gamma.m
@@ -1,7 +1,8 @@
-function [bs, t] = pspm_bf_spsrf_gamma( td,soa,p)
+function [bs, t] = pspm_bf_spsrf_gamma(varargin)
 % pspm_bf_spsrf_box basis 
 % 
-%   FORMAT: [bf p] = pspm_bf_spsrf_gamma(td, soa,p)
+%   FORMAT: [bf p] = pspm_bf_spsrf_gamma(td,soa,p) OR
+%           [bf p] = pspm_bf_spsrf_gamma([td,soa,p])
 %           with  td = time resolution in s
 %                 p(1) = A
 %                 p(2) = x0
@@ -15,20 +16,25 @@ function [bs, t] = pspm_bf_spsrf_gamma( td,soa,p)
 global settings
 if isempty(settings), pspm_init; end;
 
-
 %check input arguments
-if nargin < 1
-   errmsg='No sampling interval stated'; warning('ID:invalid_input',errmsg); return;
+if nargin==0
+    errmsg='No sampling interval stated'; warning('ID:invalid_input', errmsg); return;
+elseif nargin == 1
+    n_el = numel(varargin{1});
+    td = varargin{1}(1);
+    if n_el > 1, soa = varargin{1}(2); else , soa=3.5; end;
+elseif nargin > 1
+    td = varargin{1};
+    soa = varargin{2};
+    if nargin > 2 
+        p = varargin{3};
+        errmsg = 'Basis function parameter must be a numeric vector with 4 elements.'
+        if ~isnumeric(p) || numel(p)~=4, warning('ID:invalid_input', errmsg); return; end;
+    else
+        % parameters obtained by fitting a gamma function to smoothed test data
+        p = [-0.00953999201164847,-1.90202591900308,10.0912982464000,0.421253777432825];
+    end;
 end;
-
-if nargin < 2
-    soa = 3;
-end;
-
-if nargin < 3
-    p=[-0.007,0,4,0.5];
-end;
-
 
 A  = p(1);
 x0 = p(2);

--- a/src/pspm_bf_spsrf_gamma.m
+++ b/src/pspm_bf_spsrf_gamma.m
@@ -22,7 +22,7 @@ if nargin < 1
 end;
 
 if nargin < 2
-    soa = 3.5;
+    soa = 3;
 end;
 
 if nargin < 3

--- a/src/pspm_glm.m
+++ b/src/pspm_glm.m
@@ -68,9 +68,12 @@ function glm = pspm_glm(model, options)
 %                   at the end of the output. In 'free' models the field
 %                   model.window is MANDATORY and single basis functions 
 %                   are allowed only.
+% model.centering:  if set to 0 the function would not perform the 
+%                   mean centering of the convolved X data.
+%                   Default: 1
 %
 % OPTIONS (optional argument)
-% options.overwrite: overwrite existing model output; default 0
+% options.overwrite:       overwrite existing model output; default 0
 % options.marker_chan_num: marker channel number; default last marker
 %                          channel
 % options.exclude_missing: marks trials during which NaN percentage exceeds
@@ -78,8 +81,7 @@ function glm = pspm_glm(model, options)
 %                          'segment_length' (in s after onset) and 'cutoff'
 %                          (in % NaN per segment). Results are written into
 %                          model structure as fields .stats_missing and 
-%                           .stats_exclude but not used further.
-%                           
+%                           .stats_exclude but not used further.                           
 %
 % TIMING - multiple condition file(s) or struct variable(s):
 % The structure is equivalent to SPM2/5/8/12 (www.fil.ion.ucl.ac.uk/spm),
@@ -230,6 +232,13 @@ if ~isfield(model, 'norm')
     model.norm = 0;
 elseif ~ismember(model.norm, [0, 1])
     warning('ID:invalid_input', 'Normalisation must be specified as 0 or 1.'); return;
+end
+
+% check mean centering --
+if ~isfield(model,'centering')
+    model.centering = 1;
+elseif ~ismember(model.centering, [0, 1])
+    model.centering = 1;
 end
 
 % check options --
@@ -727,11 +736,13 @@ for iCond = 1:numel(names)
         end
     end
     
-    % mean center
-    for iXCol=1:size(tmp.XC{iCond},2)
-        tmp.XC{iCond}(:,iXCol) = tmp.XC{iCond}(:,iXCol) - mean(tmp.XC{iCond}(:,iXCol));
+    % mean centering
+    if model.centering
+        for iXCol=1:size(tmp.XC{iCond},2)
+            tmp.XC{iCond}(:,iXCol) = tmp.XC{iCond}(:,iXCol) - mean(tmp.XC{iCond}(:,iXCol));
+        end
     end
-    
+
     % orthogonalize after convolution if there is more than one column per
     % condition
     if size(tmp.XC{iCond}, 2) > 1


### PR DESCRIPTION
Fixes an unoppened issue.

Changes proposed in this pull request:
- New option for models in GLM which is `model.centering` and can be set to `[0,1]` depending on the need of mean centering the convolved X data or not. By default is equal to 1 (because GLM was by default doing this step).
- `pspm_bf_spsrf_box` was not adapted for its use in GLM, so I've modified that.
- `pspm_bf_spsrf_gamma.m` had the same issue plus some inconsistencies wrt. Yanfang's paper.

Every modification was made according to Yanfang's requests and needs.