### PR TITLE
Use the last gaze chan in pupil_correct_eyelink

### DIFF
--- a/src/pspm_pupil_correct_eyelink.m
+++ b/src/pspm_pupil_correct_eyelink.m
@@ -217,6 +217,15 @@ function [sts, out_channel] = pspm_pupil_correct_eyelink(fn, options)
     [lsts, infos, gaze_y_data] = pspm_load_data(fn, gaze_y_chan);
     if lsts ~= 1; return; end
 
+    if numel(gaze_x_data) > 1
+        warning('ID:multiple_channels', 'There are more than one gaze x channel. We will use the last one');
+        gaze_x_data = gaze_x_data(end:end);
+    end
+    if numel(gaze_y_data) > 1
+        warning('ID:multiple_channels', 'There are more than one gaze y channel. We will use the last one');
+        gaze_y_data = gaze_y_data(end:end);
+    end
+
     % conditionally mandatory input checks
     % -------------------------------------------------------------------------
     if strcmp(gaze_x_data{1}.header.units, 'pixel') || strcmp(gaze_y_data{1}.header.units, 'pixel')


### PR DESCRIPTION
Changes proposed in this pull request:
- Use the last gaze channel in `pspm_pupil_correct_eyelink` when there are multiple gaze x (similarly y) channels in the file.

This is a reasonable default (which is also the case in GLM) since preprocessing functions either append the new channel to the pspm file or replace (in which case this option is irrelevant anyways).