### PR TITLE
Mult NaN ratio with 100 in extract_segments

### DIFF
--- a/src/pspm_extract_segments.m
+++ b/src/pspm_extract_segments.m
@@ -613,8 +613,8 @@ function [sts, out] = pspm_extract_segments(varargin)
         
         segments{c}.std = nanstd(m,0,2);
         segments{c}.sem = segments{c}.std./sqrt(n_onsets_in_cond{c});
-        segments{c}.trial_nan_percent = sum(isnan(m))/size(m,1);
-        segments{c}.total_nan_percent = sum(sum(isnan(m)))/numel(m);
+        segments{c}.trial_nan_percent = 100.0 * sum(isnan(m))/size(m,1);
+        segments{c}.total_nan_percent = 100.0 * sum(sum(isnan(m)))/numel(m);
         %   segments{c}.total_nan_percent = mean(segments{c}.trial_nan_percent);
         
         

--- a/test/pspm_extract_segments_test.m
+++ b/test/pspm_extract_segments_test.m
@@ -147,8 +147,8 @@ classdef pspm_extract_segments_test < matlab.unittest.TestCase
                 control_data{i}.cond_name         = cond_names{i};
                 control_data{i}.mean              = cond_trial_mean{i};
                 control_data{i}.std               = cond_trial_std{i};
-                control_data{i}.trial_nan_percent = cond_nan_trial{i};
-                control_data{i}.total_nan_percent = cond_nan_total{i};
+                control_data{i}.trial_nan_percent = cond_nan_trial{i}*100;
+                control_data{i}.total_nan_percent = cond_nan_total{i}*100;
             end
         end
     end
@@ -217,7 +217,7 @@ classdef pspm_extract_segments_test < matlab.unittest.TestCase
                  this.verifyEqual(seg.name,control.cond_name);
                  this.verifyEqual(seg.mean,control.mean);
                  this.verifyEqual(seg.std,control.std);
-                 this.verifyEqual(seg.trial_nan_percent,control.trial_nan_percent);
+                 this.verifyTrue(all(abs(seg.trial_nan_percent-control.trial_nan_percent)<1e-12));
                  this.verifyTrue(abs(seg.total_nan_percent-control.total_nan_percent)<1e-12);
              end
          end
@@ -247,7 +247,7 @@ classdef pspm_extract_segments_test < matlab.unittest.TestCase
                  this.verifyEqual(seg.name,control.cond_name);
                  this.verifyEqual(seg.mean,control.mean);
                  this.verifyEqual(seg.std,control.std);
-                 this.verifyEqual(seg.trial_nan_percent,control.trial_nan_percent);
+                 this.verifyTrue(all(abs(seg.trial_nan_percent-control.trial_nan_percent)<1e-12));
                  this.verifyTrue(abs(seg.total_nan_percent-control.total_nan_percent)<1e-12);
              end
          end

--- a/test/pspm_glm_test.m
+++ b/test/pspm_glm_test.m
@@ -650,10 +650,10 @@ classdef pspm_glm_test < matlab.unittest.TestCase
                 nr_nan_toadd = round(nan_percent *  nr_samples);
                 idx_replace = randsample(nr_samples, nr_nan_toadd);
                 Y(idx_replace) = NaN;
-                new_nan_percent = sum(isnan(Y))/nr_samples;
+                new_nan_percent = sum(isnan(Y))/nr_samples * 100;
                 
             else
-                new_nan_percent = nan_percent;
+                new_nan_percent = nan_percent * 100;
             end
             
             %t
@@ -666,7 +666,7 @@ classdef pspm_glm_test < matlab.unittest.TestCase
             this.verifyEqual(length(glm.stats_missing),exptected_number_of_conditions, sprintf('test_extract_missing: glm.stats_missing does not have the expected number (%i) of elements', exptected_number_of_conditions));
             this.verifyEqual(length(glm.stats_exclude),exptected_number_of_conditions, sprintf('test_extract_missing: glm.stats_exclude does not have the expected number (%i) of elements', exptected_number_of_conditions));
             
-            this.verifyTrue((abs(mean(glm.stats_missing)-new_nan_percent)<0.01), sprintf('test_extract_missing: mean of glm.stats_missing (%i) does not correspond to expected nan_percentage (%i)', mean(glm.stats_missing), new_nan_percent));
+            this.verifyTrue((abs(mean(glm.stats_missing)-new_nan_percent) < 1), sprintf('test_extract_missing: mean of glm.stats_missing (%i) does not correspond to expected nan_percentage (%i)', mean(glm.stats_missing), new_nan_percent));
             
             check_values = glm.stats_missing > cutoff;
             this.verifyTrue(all(glm.stats_exclude == check_values), sprintf('test_extract_missing: glm.stats_exclude does not exclude the right conditions'));


### PR DESCRIPTION
Fixes #107 .

Changes proposed in this pull request:
- Return `NaN` percentages, not ratios from `pspm_extract_segments`