### PR TITLE
fix(struct-load): access after load

### DIFF
--- a/src/pspm_butter.m
+++ b/src/pspm_butter.m
@@ -38,12 +38,12 @@ function [sts, b, a] = pspm_butter(order, freqratio, pass)
     if settings.signal
          [b, a]=butter(order, freqratio, pass);
     else
-        filt = load('pspm_butter.mat').filt;
+        F = load('pspm_butter.mat', 'filt');
         switch pass
             case 'low'
-                f = filt{1};
+                f = F.filt{1};
             case 'high'
-                f = filt{2};
+                f = F.filt{2};
         end;
         d = abs([f.freqratio] - freqratio);
         n = find(d < .0001);


### PR DESCRIPTION
Fixes NaN.

Changes proposed in this pull request:
- access filt struct after loading.

Guillame Flandin from SPM pointed out access the filt from the struct in a chained fashion from the load would fail in older versions of matlab
