### PR TITLE
fix(dcm-xticks): scale xtick label by sample rate

### DIFF
--- a/src/pspm_rev_dcm.m
+++ b/src/pspm_rev_dcm.m
@@ -78,6 +78,8 @@ switch job
             data = [y(win), yhat(win)];
             subplot(f.r, f.c, n);
             plot(data);
+            xt = get(gca, 'XTick');
+            set(gca, 'XTickLabel', xt * dcm.input.sr);
             set(gca, 'YLim', [min(yhat), max(yhat)]);
         end;
         


### PR DESCRIPTION
Fixes #124  .

Changes proposed in this pull request:
- Scale xticks by the sample rate from the dcm input data

