### PR TITLE
Add an option to take into account random ITIs

### DIFF
--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -30,6 +30,10 @@ function newdatafile = pspm_split_sessions(datafile, markerchannel, options)
 %                           Default = 0
 % options.verbose           Tell the function to display information
 %                           about the state of processing. Default = 0
+% options.randomITI         Tell the function to use all the markers to
+%                           evaluate the mean distance between them.
+%                           Usefull for random ITI since it reduce the
+%                           variance. Default = 0
 %
 %       REMARK for suffix and prefix:
 %           The prefix and  suffix intervals will only be applied to data -
@@ -90,6 +94,8 @@ catch
     options.min_break_ratio = settings.split.min_break_ratio;
 end
 
+try options.randomITI; catch, options.randomITI = 0; end
+
 % check input arguments
 % -------------------------------------------------------------------------
 if nargin < 1
@@ -122,6 +128,10 @@ end
 
 if ~isnumeric(options.splitpoints)
     warning('ID:invalid_input', 'options.splitpoints has to be numeric.'); return;
+end
+
+if ~isnumeric(options.randomITI) || ~ismember(options.randomITI, [0, 1])
+    warning('ID:invalid_input', 'options.randomITI has to be numeric and equal to 0 or 1.'); return;
 end
 
 % work on all data files
@@ -185,7 +195,7 @@ for d = 1:numel(D)
             % relevant data within the mean space
             
             % add global mean space
-            if sta == sto
+            if sta == sto || options.randomITI
                 mean_space = mean(diff(mrk));
             else
                 mean_space = mean(diff(mrk(sta:sto)));


### PR DESCRIPTION
Fixes an issue spotted by Jelena.

Issue description:
When trying to split session per blocks using `pspm_split_sessions` in data where marker distances are not constant (random ITI), you can end up with session which contains more markers than needed. 
Example: you have 40 markers in data and 4 blocks, you want to split uniformly, but due to random marker distances (not going much in details) the session 3 is found to have 11 markers instead of 10 such that after processing and recombining the data you will have 41 markers instead of 40.

Changes proposed in this pull request:
- In this pull request, I implemented an option which I called `randomITI` and which can take the values 1 or 0 (default: 0)
- What it does is to evaluate the mean marker distance not per session but on the all the markers.

I am waiting for Jelena to confirm me that it reproduces the results correctly (for data which worked well) and then I will submit for review.
