### PR TITLE
fix(descending marker events): update index for descending events

### DIFF
--- a/src/pspm_get_events.m
+++ b/src/pspm_get_events.m
@@ -90,7 +90,7 @@ elseif strcmpi(import.marker, 'continuous')
         mPos = lo2hi+3; 
     elseif isfield(import, 'flank') && strcmpi(import.flank, 'descending')
         import.data = (hi2lo+1)./import.sr;
-        mPos = hi2lo+2;
+        mPos = hi2lo+3;
     elseif numel(lo2hi) == numel(hi2lo)
         % only use mean if amount of minima corresponds to amount of maxima
         % otherwise output a warning

--- a/test/pspm_get_marker_test.m
+++ b/test/pspm_get_marker_test.m
@@ -3,10 +3,15 @@ classdef pspm_get_marker_test < matlab.unittest.TestCase
 % unittest class for the pspm_get_marker function
 %__________________________________________________________________________
 % SCRalyze TestEnvironment
-% (C) 2013 Linus Rüttimann (University of Zurich)
+% (C) 2013 Linus RÃ¼ttimann (University of Zurich)
+
+    properties (TestParameter)
+        flank = { 'descending', 'ascending' };
+        sr = { 1, 2 };
+    end
 
     methods (Test)
-        function test(this)
+        function timestamps(this)
             import.sr = 1;
             import.data = 1:10;
             import.marker = 'timestamps';
@@ -20,6 +25,26 @@ classdef pspm_get_marker_test < matlab.unittest.TestCase
             this.verifyEqual(data.header.sr, 1);
             
         end
+
+        function continuous(this, flank, sr)
+            import.sr = sr;
+            import.data = [ 42, 42, 84, 84, 84, 42, 42, 42, 84, 42 ];
+            import.marker = 'continuous';
+            import.flank = flank;
+            [sts, data] = pspm_get_marker(import);
+            
+            expected = struct(...
+                'descending', [ 6; 10 ], ...
+                'ascending', [ 3; 9 ]...
+            );
+
+            this.verifyEqual(sts, 1);
+            this.verifyEqual(data.data, expected.(flank) ./ sr);
+            this.verifyTrue(strcmpi(data.header.chantype, 'marker'));
+            this.verifyTrue(strcmpi(data.header.units, 'events'));
+            this.verifyEqual(data.header.sr, 1);
+        end
+
     end
     
 end


### PR DESCRIPTION
Fixes #115  .

Changes proposed in this pull request:
- correct index offset when dealing with the descending flank for continuous markers

