### PR TITLE
import_viewpoint doesn't import the right number of datapoints

### DIFF
--- a/src/Import/viewpoint/import_viewpoint.m
+++ b/src/Import/viewpoint/import_viewpoint.m
@@ -114,7 +114,7 @@ function [dataraw, marker, messages, chan_info, file_info] = parse_viewpoint_fil
         begidx = linefeeds(msg_line) + 1;
         str(begidx : begidx + 1) = '/';
     end
-    C = textscan(str, fmt_str, 'Delimiter', '\t', 'CollectOutput', 1, 'CommentStyle', '//');
+    C = textscan(str, fmt_str, 'CollectOutput', 1, 'CommentStyle', '//');
     dataraw = C{1};
     marker = C{2};
 

--- a/test/import_viewpoint_test.m
+++ b/test/import_viewpoint_test.m
@@ -83,7 +83,7 @@ classdef import_viewpoint_test < matlab.unittest.TestCase
             % ---------------------------------------------------------------------------
             msg_counter = 1;
             for line = datalines
-                parts = split(line, sprintf('\t'));
+                parts = strsplit(line{1},'\t');
                 msg = parts{marker_index};
                 if ~isempty(msg)
                     tbeg = to_num(parts{2});


### PR DESCRIPTION
Fixes a bug that I've discovered while importing a viewpoint file. Here is a test file (anonymized): [test_data.txt](https://github.com/bachlab/PsPM/files/4959048/test_data.txt)

*Bug description:*
For importing a viewpoint file in PsPM, `import_viewpoint` function uses `textscan` Matlab function to read formatted data from the text file. The format is determined by a `formatSpecs` character array which is created by `get_columns_to_read` function (cf. `import_viewpoint.m` file), e.g. `%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%s` (num. of col depend on the file). But as one can see it already contains the delimiter and thus it shouldn't be specified in options of the `textscan` function. Moreover when specifying it the `textscan` stops at the first marker because `formatSpecs` do not match anymore.

*Reproducing the bug:*
Execute: `import_viewpoint('test_data.txt')`. You'll see that the data array contains only 15k points instead of the 200k and in the marker field there is only one point (starting marker '+,+').

*Expected result:*
Execute: `import_viewpoint('test_data.txt')` (after making the changes). You'll see that the data array contains the right number of points and in the marker field there are all the specified point.

*Changes proposed in this pull request:*
- Remove 'Delimiter' option in `textscan` function in the `parse_viewpoint_file` function used by `import_viewpoint`
