### PR TITLE
pspm_display crashes when loading data

### DIFF
--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -411,10 +411,17 @@ if not(sts==0)
     handles.name=filename;
     guidata(hObject, handles);
     
+    % ---set wave and event channel value to none ---------------------
+    handles.prop.wave='none';
+    set(handles.wave_listbox,'Value',1)
+    
+    handles.prop.event='none';
+    set(handles.event_listbox,'Value',1)
+    
     % ---add text to wave listbox--------------------------------------
     
     listitems{1,1}='none';
-    handles.prop.wavechans(1)=0;
+    handles.prop.wavechans(1)=0;   
     j=2;
     for k=1:length(handles.data)
         if any(strcmp(handles.data{k,1}.header.chantype,handles.prop.setwave))
@@ -836,10 +843,10 @@ elseif not(isempty(marker)) || not(isempty(wave)) || not(isempty(hbeat)) || not(
             legend(handles.prop.wave,'heartbeats')
         elseif not(isempty(events))
             legend(handles.prop.wave,[handles.event_listbox.String{handles.prop.idevent},' events'])
-        elseif not(strcmp(handles.prop.event,'none')) && not(strcmp(handles.prop.wave,'none'))
-            legend(handles.prop.wave)
-        else
+        elseif not(strcmp(handles.prop.event,'none'))
             legend(handles.prop.wave,'unknown events')
+        else 
+            legend(handles.prop.wave)
         end
         
         %   plotting if only event channel is selected


### PR DESCRIPTION
Fixes an issue reported by @dominikbach .

## Issue description
In the current implementation, `pspm_display` crashes when someone first plots data with many wave/event channels and then tries to load data with less wave/events channels.

## Steps to reproduce the issue
- execute `pspm_display('any_pspm_data_file.mat')`
- lets say it has 7 wave channels
- select and plot channel 6 for instance
- now click on the button "load" in the top left corner of the window
- select a file which has less than 6 wave channels
- click "Done.", you'll then see a warning in the Command window and on top of that the wave list box will disappear !
(same procedure with event channels)

## What's happening ?
What `pspm_display` currently does is just to replace the list in the `wave_listbox`/`event_listbox` instances but not the value of the list box, so when it finishes the loading it cannot display the list boxes since the value happens to be bigger than the list length.

## Changes proposed in this pull request:
- Reset the value of the listbox to 1 before starting to load new data (value=1 correspond to 'none' wave/event channel option)
- Fix a minor bug with the legend
