### PR TITLE
Modify the way warnings are stored in pspm_dcm

### DIFF
--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -142,9 +142,12 @@ rev = '$Rev: 792 $';
 % ------------------------------------------------------------------------
 global settings;
 if isempty(settings), pspm_init; end;
-warnings = {};
 
 dcm = [];
+
+% cell array which saves all the warnings which are not followed
+% by a `return` function
+warnings = {};
 
 % check input arguments & set defaults
 % -------------------------------------------------------------------------
@@ -573,6 +576,7 @@ for iSn = 1:numel(model.timing)
     else
         warning('Could not find any enabled trial for file ''%s''', ...
             model.datafile{iSn});
+        [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
     end
 end
 
@@ -633,15 +637,15 @@ clear flexseq fixseq flexevents fixevents startevent
 
 % check ITI --
 if (options.indrf || options.getrf) && min(proc_miniti) < 5
-    warnings{1} = ('Inter trial interval is too short to estimate individual CRF - at least 5 s needed. Standard CRF will be used instead.');
-    fprintf('\n%s\n', warnings{1});
+    warning('Inter trial interval is too short to estimate individual CRF - at least 5 s needed. Standard CRF will be used instead.');
+    [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
     options.indrf = 0;
 end;
 
 % extract PCA of last fixed response (eSCR) if last event is fixed --
 if (options.indrf || options.getrf) && (isempty(options.flexevents) ...
         || (max(options.fixevents > max(options.flexevents(:, 2), [], 2))))
-    [foo, lastfix] = max(options.fixevents);
+    [ ~ , lastfix] = max(options.fixevents);
     % extract data
     winsize = round(model.sr * min([proc_miniti 10]));
     D = []; c = 1;
@@ -652,7 +656,7 @@ if (options.indrf || options.getrf) && (isempty(options.flexevents) ...
         foo(foo < 0) = [];
         for n = 1:size(foo, 1)
             win = ceil(model.sr * foo(n) + (1:winsize));
-            row = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, model.iti, proc_miniti);
+            [row,warnings] = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, model.iti, proc_miniti, warnings);
             D(c, 1:numel(row)) = row;
             c = c + 1;
         end;
@@ -680,14 +684,15 @@ if (options.indrf || options.getrf) && (isempty(options.flexevents) ...
         der = conv(der, ones(10, 1));
         der = der(ceil(3 * model.sr):end);
         if all(der > 0) || all(der < 0)
-            warnings{1} = ('No peak detected in response to outcomes. Cannot individually adjust CRF. Standard CRF will be used instead.');
-            fprintf('\n%s\n', warnings{1});
+            warning('ID:PCA_eSCR','No peak detected in response to outcomes. Cannot individually adjust CRF. Standard CRF will be used instead.');
+            [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
             options.indrf = 0;
         else
             options.eSCR = eSCR;
         end;
     else
         warning('ID:invalid_input', 'Due to NaNs after some trial endings, PCA could not be computed');
+        [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
     end
 end;
 
@@ -700,7 +705,7 @@ for isbSn = 1:numel(model.scr)
         win = ceil(((model.sr * model.trlstart{isbSn}(n)):(model.sr * model.trlstop{isbSn}(n) + winsize)));
         % correct rounding errors
         win(win == 0) = [];
-        row = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, model.iti, proc_miniti);
+        [row,warnings] = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, model.iti, proc_miniti, warnings);
         D(c, 1:numel(row)) = row;
         c = c + 1;
     end;
@@ -730,6 +735,7 @@ if (options.indrf || options.getrf) && ~isempty(options.flexevents)
         options.aSCR = aSCR;
     else
         warning('ID:invalid_input', 'Due to NaNs after some trial endings, PCA could not be computed');
+        [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
     end
 end;
 
@@ -739,7 +745,6 @@ options.meanSCR = (nanmean(D))';
 % invert DCM
 % ------------------------------------------------------------------------
 dcm = pspm_dcm_inv(model, options);
-
 
 % assemble stats & names
 % ------------------------------------------------------------------------
@@ -811,7 +816,7 @@ end;
 
 end
 
-function datacol = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, sbs_iti, proc_miniti)
+function [datacol, warnings] = get_data_after_trial_filling_with_nans_when_necessary(scr_sess, win, n, isbSn, sbs_iti, proc_miniti, warnings)
     % Try to get all the data elements after the end of the trial n in session isbSn. Indices of the elements
     % to return are stored in win. In case these indices are larger than size of scr_sess{isbSn}, then fill the
     % rest of the data with NaN values.
@@ -824,6 +829,7 @@ function datacol = get_data_after_trial_filling_with_nans_when_necessary(scr_ses
                 ' after each trial. Filling the rest with NaNs'],...
                 n, isbSn, sbs_iti{isbSn}(n), proc_miniti(isbSn)...
         ));
+        [warnings{end+1,2},warnings{end+1,1}] = lastwarn;
         win(end - num_indices_outside_scr + 1 : end) = [];
         datacol(1:numel(win)) = scr_sess(win);
         datacol(numel(win) + 1 : end) = NaN;

--- a/src/pspm_dcm_inv.m
+++ b/src/pspm_dcm_inv.m
@@ -163,7 +163,7 @@ if isfield(options, 'rf')
     elseif isnumeric(options.rf)
         theta = options.rf;
     else
-        warning('Unknown RF format (must be file name or numeric).');
+        warning('Unknown RF format (must be file name or numeric).'); return;
     end;
     if numel(theta) ~= theta_n
         warning('Wrong number of parameters specified.'); return; 


### PR DESCRIPTION
Improvement suggested by Karita.

Previously `pspm_dcm` was not catching all the warnings which didn't lead to an end of file (i.e. not followed by a "return;"), typically the warning emitted by the function `get_data_after_trial_filling_with_nans_when_necessary` (btw we have to find a new shorter and more explicit name for it) was forgotten. 
This is especially anoying when DCM is used for many subjects at once, because the user has to scroll the command window history in order to find which subject had a warning.

Changes proposed in this pull request:
- A new (easier ?) implementation for saving warnings which do not lead to a "return;".
- Add a forgotten "return;" in `pspm_dcm_inv` 
