### PR TITLE
fix bugs in split_sessions

### DIFF
--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -228,18 +228,7 @@ for d = 1:numel(D)
             else
                 sto = max(1,splitpoint(s) - 1);
             end
-            % include last space (estimated by mean space)
-            % do not cut immedeately after stop because there might be some
-            % relevant data within the mean space.
-            % Add global mean space
-            %if sta == sto || options.randomITI
-            %   mean_space = mean(diff(mrk));
-            %else
-            %   mean_space = mean(diff(mrk(sta:sto)));
-            %end
-            start_time = mrk(sta);
-            %stop_time = mrk(sto)+mean_space;
-            stop_time = mrk(sto);
+           
             if options.suffix == 0
                 if sta == sto || options.randomITI
                     suffix(s) = mean(diff(mrk));
@@ -249,15 +238,7 @@ for d = 1:numel(D)
             else
                 suffix(s) = options.suffix;
             end
-            % correct starttime (we cannot go into -) ---
-            if start_time <= 0
-                start_time = 0;
-            end
-            % correct stop_time if it exceeds duration of file
-            if stop_time > ininfos.duration
-                stop_time = ininfos.duration;
-            end
-            spp(s,:) = [start_time, stop_time];
+            spp(s,:) = [sta, sto];
         end
         splitpoint = spp;
         
@@ -275,13 +256,13 @@ for d = 1:numel(D)
             
             trimoptions = struct('overwrite', options.overwrite, 'drop_offset_markers', 1);
             newfn = pspm_trim(datafile, options.prefix, options.suffix, splitpoint(sn, 1:2), trimoptions);
-            pspm_rename(newfn, newdatafile{d}{sn});
+            pspm_ren(newfn, newdatafile{d}{sn});
 
            
-            % 2.4.5 Split Epochs
+            % 2.4.5 Split Epochs - to be updated
             if options.missing && ~isempty(missing)
-                startpoint = max(1, ceil(sta_p * srscr)); % convert from seconds into datapoints
-                stoppoint  = min(floor(sto_p * srscr), numel(datascr{1}.data));
+                startpoint = max(1, ceil((mrk(splitploint(:, 1)) - options.prefix) * srscr)); % convert from seconds into datapoints
+                stoppoint  = min(floor((mrk(splitploint(:, 2)) + options.suffix) * srscr), numel(datascr{1}.data));
                 epochs = dp_epochs(startpoint:stoppoint);
                 epoch_on = strfind(epochs.', [0 1]); % Return the start points of the excluded interval
                 epoch_off = strfind(epochs.', [1 0]); % Return the end points of the excluded interval

--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -240,9 +240,8 @@ for d = 1:numel(D)
                 [p_epochs, f_epochs, ex_epochs] = fileparts(options.missing);
                 newepochfile{d}{sn} = fullfile(p_epochs, sprintf('%s_sn%02.0f%s', f_epochs, sn, ex_epochs));
             end
-            
             trimoptions = struct('drop_offset_markers', 1);
-            newdata = pspm_trim(struct('data', indata, 'infos', ininfos), ...
+            newdata = pspm_trim(struct('data', {indata}, 'infos', ininfos), ...
                  options.prefix, suffix(sn), trimpoint(sn, 1:2), trimoptions);
             newdata.options = struct('overwrite', options.overwrite);
             pspm_load_data(newdatafile{d}{sn}, newdata);

--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -241,9 +241,11 @@ for d = 1:numel(D)
                 newepochfile{d}{sn} = fullfile(p_epochs, sprintf('%s_sn%02.0f%s', f_epochs, sn, ex_epochs));
             end
             
-            trimoptions = struct('overwrite', options.overwrite, 'drop_offset_markers', 1);
-            newfn = pspm_trim(datafile, options.prefix, suffix(sn), trimpoint(sn, 1:2), trimoptions);
-            pspm_ren(newfn, newdatafile{d}{sn});
+            trimoptions = struct('drop_offset_markers', 1);
+            newdata = pspm_trim(struct('data', indata, 'infos', ininfos), ...
+                 options.prefix, suffix(sn), trimpoint(sn, 1:2), trimoptions);
+            newdata.options = struct('overwrite', options.overwrite);
+            pspm_load_data(newdatafile{d}{sn}, newdata);
 
            
             % 2.4.5 Split Epochs - to be updated

--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -81,8 +81,7 @@ end
 % 1.2 Set options
 if ~exist('options','var') || isempty(options) || ~isstruct(options)
     options = struct();
-end
-if ~exist('options.overwrite','var')
+elseif ~isfield(options, 'overwrite')
     options.overwrite = 0;
 elseif options.overwrite ~= 1
     options.overwrite = 0;

--- a/src/pspm_split_sessions.m
+++ b/src/pspm_split_sessions.m
@@ -69,7 +69,8 @@ end
 % 1.2 Set options
 if ~exist('options','var') || isempty(options) || ~isstruct(options)
     options = struct();
-elseif ~isfield(options, 'overwrite')
+end
+if ~isfield(options, 'overwrite')
     options.overwrite = 0;
 elseif options.overwrite ~= 1
     options.overwrite = 0;

--- a/src/pspm_trim.m
+++ b/src/pspm_trim.m
@@ -145,7 +145,12 @@ function newdatafile = pspm_trim(datafile, from, to, reference, options)
         return;
     end
     % 1.6 Set options
-    if ~exist('options.overwrite','var')
+    if ~exist('options','var') || isempty(options) || ~isstruct(options)
+        options = struct();
+    end
+    if ~isfield(options, 'overwrite')
+        options.overwrite = 0;
+    elseif options.overwrite ~= 1
         options.overwrite = 0;
     end
     if ~isfield(options,'marker_chan_num') || ...

--- a/test/pspm_split_sessions_test.m
+++ b/test/pspm_split_sessions_test.m
@@ -32,11 +32,12 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
             channels{3}.chantype = 'marker';
             datastruct = pspm_testdata_gen(channels, 100);
             datastruct.data{3}.data = [1 4 9 12 30 31 34 41 43 59 65 72 74 80 89 96]'; %with default values MAXSN=10 & BRK2NORM=3 the datafile should be split into 3 files
+            datastruct.options = struct('overwrite', 1);
             pspm_load_data(fn, datastruct); %save datafile
             %datafile.data{3}.data = [0 1]';
             %save(fn, '-struct', 'datafile');
-            
-            newdatafile = pspm_split_sessions(fn);
+            options = struct('overwrite', 1);
+            newdatafile = pspm_split_sessions(fn, 0, options);
             
             this.verifyTrue(numel(newdatafile) == this.expected_number_of_files, sprintf('the testdatafile %s has been split into %i files and not like expected into %i files', fn, numel(newdatafile), this.expected_number_of_files));
             
@@ -60,12 +61,14 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
             channels{3}.chantype = 'marker';
             datastruct = pspm_testdata_gen(channels, 100);
             datastruct.data{3}.data = [1 4 9 12 30 31 34 41 43 59 65 72 74 80 89 96]'; %with default values MAXSN=10 & BRK2NORM=3 the datafile should be split into 3 files
-            
+            datastruct.options = struct('overwrite', 1);
+
             for m=1:numel(fn)
                 pspm_load_data(fn{m}, datastruct); %save datafile
             end
             
-            newdatafile = pspm_split_sessions(fn, 3);
+            options = struct('overwrite', 1);
+            newdatafile = pspm_split_sessions(fn, 3, options);
             
             this.verifyTrue(numel(fn) == numel(newdatafile));
             
@@ -93,8 +96,11 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
             channels{3}.variance = 0.05;
 
             % 6 minutes data
-            pspm_testdata_gen(channels, 60*6, fn);            
-            newdatafile = pspm_split_sessions(fn, 3);
+            pspm_testdata_gen(channels, 60*6, fn); 
+                       
+            options = struct('overwrite', 1);
+
+            newdatafile = pspm_split_sessions(fn, 3, options);
             
             this.verifyEqual(numel(newdatafile), nsessions);
             
@@ -122,7 +128,7 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
             
             % 6 minutes data
             data = pspm_testdata_gen(channels, 60*6, fn);
-            options = struct('prefix', prefix, 'suffix', suffix);
+            options = struct('prefix', prefix, 'suffix', suffix, 'overwrite', 1);
             newdatafile = pspm_split_sessions(fn, 3, options);
             
             this.verifyEqual(numel(newdatafile),10);
@@ -177,6 +183,7 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
             end
             
             options.splitpoints = splitpoints;
+            options.overwrite = 1;
             newdatafile = pspm_split_sessions(fn, 3, options);
             if ~isempty(splitpoints)
                 n_sess_exp = numel(splitpoints)+1;

--- a/test/pspm_split_sessions_test.m
+++ b/test/pspm_split_sessions_test.m
@@ -44,9 +44,6 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
                 [sts, infos, data] = pspm_load_data(newdatafile{k});
                 this.verifyTrue(sts == 1, sprintf('couldn''t load file %s with pspm_load_data', newdatafile{k}));
                 this.verifyTrue(numel(data) == numel(channels), sprintf('number of channels doesn''t match in file %s', newdatafile{k}));
-                this.verifyTrue(isfield(infos, 'splitdate'), sprintf('there is no field infos.splitdate in file %s', newdatafile{k}));
-                this.verifyTrue(isfield(infos, 'splitsn'), sprintf('there is no field infos.splitsn in file %s', newdatafile{k}));
-                this.verifyTrue(isfield(infos, 'splitfile'), sprintf('there is no field infos.splitfile in file %s', newdatafile{k}));
                 
                 delete(newdatafile{k});
             end
@@ -78,10 +75,7 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
                     [sts, infos, data] = pspm_load_data(newdatafile{m}{k});
                     this.verifyTrue(sts == 1, sprintf('couldn''t load file %s with pspm_load_data', newdatafile{m}{k}));
                     this.verifyTrue(numel(data) == numel(channels), sprintf('number of channels doesn''t match in file %s', newdatafile{m}{k}));
-                    this.verifyTrue(isfield(infos, 'splitdate'), sprintf('there is no field infos.splitdate in file %s', newdatafile{m}{k}));
-                    this.verifyTrue(isfield(infos, 'splitsn'), sprintf('there is no field infos.splitsn in file %s', newdatafile{m}{k}));
-                    this.verifyTrue(isfield(infos, 'splitfile'), sprintf('there is no field infos.splitfile in file %s', newdatafile{m}{k}));
-
+                   
                     delete(newdatafile{m}{k});
                 end
             


### PR DESCRIPTION
Fixes #250, #251, #254 

Changes proposed in this pull request:
- fix bug with overwrite
- enable full use of pspm_trim, thus slashing down code volume in pspm_split_sessions
- this removes a remaining bug (typo: makerinfo instead of markerinfo)
