### PR TITLE
Sort missing epochs in pspm_dcm

### DIFF
--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -321,13 +321,15 @@ for iSn = 1:numel(model.datafile)
         [~, missing{iSn}] = pspm_get_timing('epochs', ...
             model.missing{iSn}, 'seconds');
         % sort missing epochs
-        [~, sortindx] = sort(missing{iSn}(:, 1));
-        missing{iSn} = missing{iSn}(sortindx,:);
-        % check for overlap and merge
-        for k = 2:size(missing{iSn}, 1)
-            if missing{iSn}(k, 1) <= missing{iSn}(k - 1, 2)
-               missing{iSn}(k, 1) =  missing{iSn}(k - 1, 1);
-               missing{iSn}(k - 1, :) = [];
+        if size(missing{iSn}, 1) > 0
+            [~, sortindx] = sort(missing{iSn}(:, 1));
+            missing{iSn} = missing{iSn}(sortindx,:);
+            % check for overlap and merge
+            for k = 2:size(missing{iSn}, 1)
+                if missing{iSn}(k, 1) <= missing{iSn}(k - 1, 2)
+                   missing{iSn}(k, 1) =  missing{iSn}(k - 1, 1);
+                   missing{iSn}(k - 1, :) = [];
+                end
             end
         end
     else

--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -440,9 +440,9 @@ for vs = 1:numel(valid_subsessions)
     sbSn = subsessions(isbSn, :);
     flanks = round(sbSn(2:3)*data{sbSn(1)}{1}.header.sr);
     sbSn_data = data{sbSn(1)}{1}.data(flanks(1):flanks(2));
-    sbs_missing{isbSn, 1} = isnan(sbSn_data);
+    sbs_miss = isnan(sbSn_data);
     
-    if any(sbs_missing{isbSn, 1})
+    if any(sbs_miss)
         interpolateoptions = struct('extrapolate', 1);
         [~, sbSn_data] = pspm_interpolate(sbSn_data, interpolateoptions);
         clear interpolateoptions
@@ -450,6 +450,11 @@ for vs = 1:numel(valid_subsessions)
     [sts, sbs_data{isbSn, 1}, model.sr] = pspm_prepdata(sbSn_data, model.filter);
     if sts == -1, return; end
     foo{vs, 1} = (sbs_data{isbSn}(:) - mean(sbs_data{isbSn}));
+    
+    % define missing epochs for inversion in final sampling rate
+    sbs_missing{isbSn, 1} = zeros(size(sbs_data{isbSn, 1}));
+    sbs_missing_indx = round(find(sbs_miss)/data{sbSn(1)}{1}.header.sr*model.sr);
+    sbs_missing{isbSn, 1}(sbs_missing_indx) = 1;
 end
 
 foo = cell2mat(foo);

--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -365,13 +365,20 @@ for iSn = 1:numel(model.datafile)
 
         % classify if epoch should be considered
         % true for duration > substhresh and for missing epochs
-        ignore_epochs = diff(miss_epochs, 1, 2)/data{1}{1}.header.sr > ...
+        ignore_epochs = diff(miss_epochs, 1, 2)/data{iSn}{1}.header.sr > ...
             model.substhresh;
 
     else
         % use missing epochs as specified by file
         miss_epochs = missing{iSn}*data{iSn}{1}.header.sr;
         ignore_epochs = diff(missing{iSn}, 1, 2) > model.substhresh;
+        
+        % and set data to NaN to enable later detection of "short" missing
+        % epochs
+        for k = 1:size(miss_epochs, 1)
+            flanks = round(miss_epochs(k,:));
+            data{iSn}{1}.data(flanks(1):flanks(2)) = NaN;
+        end
     end
     
     if any(ignore_epochs)
@@ -417,6 +424,8 @@ for iSn = 1:numel(model.datafile)
     else
         subsessions(end+1,1:4) = [iSn, ...
             [1, numel(data{iSn}{1}.data)]/data{iSn}{1}.header.sr, 0];
+        
+        
     end
 end
 

--- a/src/pspm_dcm_inv.m
+++ b/src/pspm_dcm_inv.m
@@ -743,7 +743,7 @@ if ~options.getrf
             
             % handle missing values
             invopt.isYout = ymissing(:)';
-            if any(ymissing), keyboard, end;
+
             % -- invert model
             [post, out]= VBA_NLStateSpaceModel(y(:)',u,f_fname,g_fname,dim,invopt);
             

--- a/src/pspm_dcm_inv.m
+++ b/src/pspm_dcm_inv.m
@@ -743,7 +743,7 @@ if ~options.getrf
             
             % handle missing values
             invopt.isYout = ymissing(:)';
-            
+            if any(ymissing), keyboard, end;
             % -- invert model
             [post, out]= VBA_NLStateSpaceModel(y(:)',u,f_fname,g_fname,dim,invopt);
             


### PR DESCRIPTION
Fixes #280 

Changes proposed in this pull request:
- sort missing epochs in pspm_dcm
- fix additional bug in the detection and processing of "short" missing epochs - at the moment these are not ignored if missing epochs are defined per missing epochs file, and they are incorrectly used when defined as NaN values

