### PR TITLE
Fix issue 298

### DIFF
--- a/src/pspm_init.m
+++ b/src/pspm_init.m
@@ -1000,7 +1000,7 @@ defaults.glm(9) = ... % GLM for SEBR (fear-conditioning)
 defaults.glm(10) = ... % GLM for Scanpath-speed
     struct('modality', 'sps', ...                               % modality name
     'modelspec', 'sps', ...                                  % modality name
-    'cbf', struct('fhandle', @pspm_bf_spsrf_box, 'args', 1), ...  % default basis function/set
+    'cbf', struct('fhandle', @pspm_bf_spsrf_box, 'args', 3.5), ...  % default basis function/set
     'filter', struct('lpfreq', NaN, 'lporder', NaN,  ...        % default filter settings
     'hpfreq', NaN, 'hporder', NaN, 'down', 1000, ...
     'direction', 'uni'), ...


### PR DESCRIPTION
Fixes #298 .

Changes proposed in this pull request:
- Update the default value for SOA in `pspm_bf_spsrf_box`.

Now `pspm_init` is updated and has the default value as 3.5 for SOA.
