### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,5 +23,5 @@ assignees: ''
 ### (Optional) Screenshots if Graphical User Interface is Used
 
 ### Technical Info
-* PsPM revision ID:
+* PsPM version:
 * MATLAB version:


### PR DESCRIPTION
We are no longer using PsPM revision ID to do version control, thus I have changed the technique information from "PsPM revision ID" to "PsPM version"
