### PR TITLE
Add the editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,jsx,html,sass,scss,css}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,8 @@ insert_final_newline = true
 
 
 # Matches multiple files with brace expansion notation
-# Set default charset
-[*.{js,jsx,html,sass,scss,css}]
+# Set default charset for matlab (.m), text (.txt), markdown (.md)
+[*.{m,txt,md}]
 charset = utf-8
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Changes proposed in this pull request:
- Create .editorconfig

[.editorconfig](https://editorconfig.org) sorted the code style across a repository. There are currently some confusing code styles (CRLF/LF, Western Europe/UTF-8) which may disrupt code reviewing. This config file can sort and generalise the code style and avoid repetitive code style confusion.