### PR TITLE
Fix issue 375 - pspm_data_editor

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -1,39 +1,33 @@
 function varargout = pspm_data_editor(varargin)
+% ● Description
 % pspm_data_editor MATLAB code for pspm_data_editor.fig
-%
-% FORMAT:
+% ● Format
 %   [varargout] = pspm_data_editor(varargin)
 %   [sts, out]  = pspm_data_editor(indata, options)
+% ● Arguments
+%   indata            Can be multiple kinds of data types. In order to use
+%                     pspm_data_editor() to edit acquisition data, the actual
+%                     data vector has to be passed via the varargin
+%                     argmument. The data should be 1xn or nx1 double vector.
 %
-% DESCRIPTION:
-%
-%
-% INPUT:
-%   indata:             Can be multiple kinds of data types. In order to use
-%                       pspm_data_editor() to edit acquisition data, the actual
-%                       data vector has to be passed via the varargin
-%                       argmument. The data should be 1xn or nx1 double vector.
-%
-%   options:
-%       .output_file:   Use output_file to specify a file the changed data
-%                       is saved to when clicking 'save' or 'apply'. Only
-%                       works in 'file' mode.
-%       .epoch_file:    Use epoch_file to specify a .mat file to import epoch data
-%                       .mat file must be a struct with an 'epoch' field
-%                       and a e x 2 matrix of epoch on- and offsets
-%                       (n: number of epochs)
-%
-% OUTPUT:
-%   out:                The output depends on the actual output type chosen in
-%                       the graphical interface. At the moment either the
-%                       interpolated data or epochs only can be chosen as
-%                       output of the function.
+%   options           [struct]
+%   ┣━.output_file    Use output_file to specify a file the changed data
+%   ┃                 is saved to when clicking 'save' or 'apply'. Only
+%   ┃                 works in 'file' mode.
+%   ┣━.epoch_file     Use epoch_file to specify a .mat file to import epoch data
+%   ┃                 .mat file must be a struct with an 'epoch' field
+%   ┃                 and a e x 2 matrix of epoch on- and offsets
+%   ┃                 (n: number of epochs)
+%   ┗━.overwrite      defines whether to overwrite the file
+% ● Outputs
+%   out:              The output depends on the actual output type chosen in
+%                     the graphical interface. At the moment either the
+%                     interpolated data or epochs only can be chosen as
+%                     output of the function.
 %__________________________________________________________________________
 % PsPM 3.1
 % (C) 2015 Tobias Moser (University of Zurich)
-%
-% PsPM 5.1
-% Updated 2021 Teddy Chao (WCHN)
+%     2021 Teddy Chao (UCL)
 
 % Begin initialization code - DO NOT EDIT
 gui_Singleton = 1;
@@ -178,7 +172,11 @@ else
           end
         end
         if write_file
-          newd.options.overwrite = 1;
+          if isfield(options, 'overwrite')
+            newd.options.overwrite = options.overwrite;
+          else
+            newd.options.overwrite = pspm_overwrite(out_file);
+          end
           [write_success, ~, ~] = pspm_load_data(out_file, newd);
           if disp_success
             if write_success
@@ -198,15 +196,7 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        if exist(out_file, 'file')
-          button = questdlg(sprintf(...
-            'File (%s) already exists. Overwrite?', out_file), ...
-            'Add channels?', 'Yes', 'No', 'No');
-          write_ok = strcmpi(button, 'Yes');
-        else
-          write_ok = true;
-        end
-        if write_ok
+        if pspm_overwrite(out_file)
           save(out_file, 'epochs');
         end
       else

--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -9,7 +9,6 @@ function varargout = pspm_data_editor(varargin)
 %                     pspm_data_editor() to edit acquisition data, the actual
 %                     data vector has to be passed via the varargin
 %                     argmument. The data should be 1xn or nx1 double vector.
-%
 %   options           [struct]
 %   ┣━.output_file    Use output_file to specify a file the changed data
 %   ┃                 is saved to when clicking 'save' or 'apply'. Only
@@ -106,31 +105,32 @@ if numel(varargin) > 1 && isstruct(varargin{2}) % load options
 end
 guidata(hObject, handles); % Update handles structure
 if numel(varargin) > 0
-  if ischar(varargin{1})
-    if exist(varargin{1}, 'file')
-      set(handles.pnlInput, 'Visible', 'on');
-      set(handles.pnlOutput, 'Visible', 'on');
-      loadFromFile(hObject, varargin{1});
-    else
-      warning('File ''%s'' does not exist.', varargin{1});
-    end
-  elseif isnumeric(varargin{1})
-    set(handles.pnlInput, 'Visible', 'off');
-    handles.data = varargin{1};
-    handles.input_mode = 'raw';
-    guidata(hObject, handles);
-    PlotData(hObject);
-    if isfield(handles, 'options') && isfield(handles.options, 'output_file')
-      set(handles.pnlOutput, 'Visible', 'off');
-    end
-    if isfield(handles, 'options') && isfield(handles.options, 'epoch_file')
-      set(handles.pnlEpoch, 'Visible', 'off');
-    end
-    if isfield(handles, 'options') && isfield(handles.options, 'epoch_file')
-      handles = guidata(hObject);
-      Add_Epochs(hObject, handles)
-    end
+  switch class(varargin{1})
+    case 'char'
+      if exist(varargin{1}, 'file')
+        set(handles.pnlInput, 'Visible', 'on');
+        set(handles.pnlOutput, 'Visible', 'on');
+        loadFromFile(hObject, varargin{1});
+      else
+        warning('File ''%s'' does not exist.', varargin{1});
+      end
+    case 'double'
+      set(handles.pnlInput, 'Visible', 'off');
+      handles.data = varargin{1};
+      handles.input_mode = 'raw';
   end
+  if isfield(handles, 'options') && isfield(handles.options, 'output_file')
+    set(handles.pnlOutput, 'Visible', 'off');
+  end
+  if isfield(handles, 'options') && isfield(handles.options, 'epoch_file')
+    set(handles.pnlEpoch, 'Visible', 'off');
+  end
+  if isfield(handles, 'options') && isfield(handles.options, 'epoch_file')
+    handles = guidata(hObject);
+    Add_Epochs(hObject, handles)
+  end
+  guidata(hObject, handles);
+  PlotData(hObject);
 end
 uiwait(handles.fgDataEditor);
 

--- a/src/pspm_overwrite.m
+++ b/src/pspm_overwrite.m
@@ -1,5 +1,5 @@
 function ow_final = pspm_overwrite(varargin)
-% DESCRIPTION
+% ● Description
 % pspm_overwrite generalises the overwriting operation
 % pspm_overwrite considers the following situations
 % - whether options.overwrite is defined
@@ -9,14 +9,14 @@ function ow_final = pspm_overwrite(varargin)
 % Only the following situation will stop PsPM to overwrite files
 % 1. if overwrite is defined as not to overwrite
 % 2. if overwrite is not defined, and users use the GUI to stop overwriting
-% ARGUMENTS
+% ● Arguments
 % fn        the name of the file to possibly overwrite
 %           can be a link if necessary
 % ow        option of overwrite if this option is presented
 %           can be a value or a struct
 %           if a value, can be 0 (not to overwrite) or 1 (to overwrite)
 %           if a struct, check if the field "overwrite" exist
-% OUTPUTS
+% ● Outputs
 % ow_final  option of overwriting determined by pspm_overwrite
 % (C) 2022 Teddy Chao (University College London)
 %% Initialise

--- a/test/pspm_scr_pp_test.m
+++ b/test/pspm_scr_pp_test.m
@@ -2,7 +2,7 @@ classdef pspm_scr_pp_test < matlab.unittest.TestCase
   % ● Description
   % unittest class for pspm_scr_pp
   % ● Authorship
-  % 2021 Teddy Chao (WCHN UCL)
+  % 2021 Teddy Chao (UCL)
   properties(Constant)
     fn = 'scr_pp_test.mat';
     duration = 10;


### PR DESCRIPTION
Fixes #375.

Changes proposed in this pull request:
- Update logic of overwrite
  - This bug was caused by the missing inherited overwrite value from the options 
- Update the logic of displaying missing epochs, when loading data from command line windows
   - This bug was caused by the missing updates of the epochs when they were loaded from the command line

