### PR TITLE
pspm_extract_segment length value checking

### DIFF
--- a/src/pspm_extract_segments.m
+++ b/src/pspm_extract_segments.m
@@ -482,7 +482,7 @@ for session_idx = 1:n_sessions
     assert(numel(onset_write_indices_in_cond_and_session) == num_onsets);
 
     for onset_idx = 1:num_onsets
-      if options.length <= 0
+      if options.length < 0
         try
           segment_length = durations_cond(onset_idx);
           if segment_length==0

--- a/src/pspm_options.m
+++ b/src/pspm_options.m
@@ -177,7 +177,7 @@ switch FunName
     options = autofill(options, 'target',                 'screen',   '*Char'           );
   case 'extract_segments'
     %% 2.22 pspm_extract_segments
-    options = autofill(options, 'length',                 1,          '>', 0            );
+    options = autofill(options, 'length',                 -1,         '>', 0            );
     options = autofill(options, 'norm',                   0,          1                 );
     options = autofill(options, 'outputfile',             '',         '*Char'           );
     options = autofill(options, 'overwrite',              0,          [1, 2]            );

--- a/src/pspm_options.m
+++ b/src/pspm_options.m
@@ -177,7 +177,7 @@ switch FunName
     options = autofill(options, 'target',                 'screen',   '*Char'           );
   case 'extract_segments'
     %% 2.22 pspm_extract_segments
-    options = autofill(options, 'length',                 -1,         '*Num'            );
+    options = autofill(options, 'length',                 1,          '>', 0            );
     options = autofill(options, 'norm',                   0,          1                 );
     options = autofill(options, 'outputfile',             '',         '*Char'           );
     options = autofill(options, 'overwrite',              0,          [1, 2]            );

--- a/src/pspm_options.m
+++ b/src/pspm_options.m
@@ -177,7 +177,7 @@ switch FunName
     options = autofill(options, 'target',                 'screen',   '*Char'           );
   case 'extract_segments'
     %% 2.22 pspm_extract_segments
-    options = autofill(options, 'length',                 -1,         '>', 1            );
+    options = autofill(options, 'length',                 -1,         '*Num'            );
     options = autofill(options, 'norm',                   0,          1                 );
     options = autofill(options, 'outputfile',             '',         '*Char'           );
     options = autofill(options, 'overwrite',              0,          [1, 2]            );


### PR DESCRIPTION
Changes proposed in this pull request:
- Update length value validation in `pspm_options` for `pspm_extract_segments`.

The value length is expected to be a negative value and should not be zero of positive. In line 485--495 at `pspm_extract_segments`, the checking code assumes the `.length` is always positive.