### PR TITLE
Fix issue 429

### DIFF
--- a/src/pspm_glm.m
+++ b/src/pspm_glm.m
@@ -873,19 +873,21 @@ end
 % glm.stats_exclude_names holds the names of the conditions to be excluded
 
 if isfield(options,'exclude_missing')
-  [sts,segments] = pspm_extract_segments('auto', glm, ...
-    struct('length', options.exclude_missing.segment_length));
-  if sts == -1
-    warning('ID:invalid_input', 'call of pspm_extract_segments failed');
-    return;
+  if options.exclude_missing.segment_length > 0
+    [sts,segments] = pspm_extract_segments('auto', glm, ...
+      struct('length', options.exclude_missing.segment_length));
+    if sts == -1
+      warning('ID:invalid_input', 'call of pspm_extract_segments failed');
+      return;
+    end
+    segments = segments.segments;
+    nan_percentages = cellfun(@(x) x.total_nan_percent,segments, ...
+      'un',0);
+    glm.stats_missing = cell2mat(nan_percentages);
+    glm.stats_exclude = glm.stats_missing > options.exclude_missing.cutoff;
+    glm.stats_exclude_names = cellfun(@(x) x.name,segments,'un',0);
+    glm.stats_exclude_names = glm.stats_exclude_names(glm.stats_exclude);
   end
-  segments = segments.segments;
-  nan_percentages = cellfun(@(x) x.total_nan_percent,segments, ...
-    'un',0);
-  glm.stats_missing = cell2mat(nan_percentages);
-  glm.stats_exclude = glm.stats_missing > options.exclude_missing.cutoff;
-  glm.stats_exclude_names = cellfun(@(x) x.name,segments,'un',0);
-  glm.stats_exclude_names = glm.stats_exclude_names(glm.stats_exclude);
 end
 %% save data
 % overwrite is determined in load1

--- a/src/pspm_options.m
+++ b/src/pspm_options.m
@@ -242,11 +242,17 @@ switch FunName
     options = autofill(options, 'trlnames',               {},         '*Cell*Char'      );
   case 'glm'
     %% 2.28 pspm_glm
-    options = autofill(options, 'bf',                     0,          1                 );
-    options = autofill(options, 'centering',              1,          0                 );
     options = autofill(options, 'norm',                   0,          1                 );
     options = autofill(options, 'overwrite',              0,          [1, 2]            );
     % options = autofill(options, 'marker_chan_num',        1,        '*Num'       );
+    if ~isfield(options, 'exclude_missing')
+      options.exclude_missing = struct('segment_length',-1,'cutoff',0);
+    else
+      if ~isfield(options.exclude_missing, 'segment_length') || ...
+          ~isfield(options.exclude_missing, 'cutoff')
+        options.invalid = 1;
+      end
+    end
     options = fill_glm(options);
   case 'import'
     %% 2.29 pspm_import


### PR DESCRIPTION
Fixes #429 .

Changes proposed in this pull request:
- In section `glm` at `pspm_options`
  - update default values for `.exclude_missing`.
  - `.bf` and `.centering` are not used thus removed.
