### PR TITLE
Fix issue overwrite

### DIFF
--- a/src/pspm_con2.m
+++ b/src/pspm_con2.m
@@ -73,7 +73,8 @@ if exist('options','var')
 end
 options = pspm_options(options, 'con2');
 %% check outfile
-if pspm_overwrite(outfile, options) == 0
+ow = pspm_overwrite(outfile, options)
+if ow == 0
   return
 end
 %% assemble input (for diagnostic checking)

--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -199,7 +199,8 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        if pspm_overwrite(out_file)
+        ow = pspm_overwrite(out_file);
+        if ow
           save(out_file, 'epochs');
         end
       else

--- a/src/pspm_get_markerinfo.m
+++ b/src/pspm_get_markerinfo.m
@@ -77,7 +77,8 @@ end
 % if necessary, write into a file
 outfn = options.filename;
 if ~isempty(outfn)
-  if pspm_overwrite(outfn, options)
+  ow = pspm_overwrite(outfn, options);
+  if ow
     save(outfn, 'markerinfo');
   end
 end

--- a/src/pspm_import.m
+++ b/src/pspm_import.m
@@ -305,8 +305,9 @@ for d = 1:numel(D)
 		savedata.infos = infos;
 		if exist('options','var')
 			savedata.options = options;
-		end
-		if pspm_overwrite(outfile{d, blk}, options)
+    end
+    ow = pspm_overwrite(outfile{d, blk}, options);
+		if ow
 			sts = pspm_load_data(outfile{d, blk}, savedata);
 		end
 		if sts ~= 1

--- a/src/pspm_options.m
+++ b/src/pspm_options.m
@@ -284,7 +284,7 @@ switch FunName
     options = fill_glm(options);
   case 'import'
     %% 2.29 pspm_import
-    options = autofill(options, 'overwrite',              0,          [1, 2]            );
+    options = autofill(options, 'overwrite',              1,          0                 );
   case 'interpolate'
     %% 2.30 pspm_interpolate
     options = autofill_channel_action(options);

--- a/src/pspm_segment_mean.m
+++ b/src/pspm_segment_mean.m
@@ -154,7 +154,8 @@ out.conditions = conditions;
 if ~isempty(options.newfile)
 	[pathstr, ~, ~] = fileparts(options.newfile);
 	if exist(pathstr, 'dir')
-		if pspm_overwrite(options.newfile, options)
+	  ow = pspm_overwrite(options.newfile, options);
+		if ow
 			segment_mean = conditions;
 			save(options.newfile, 'segment_mean');
 		end


### PR DESCRIPTION
Fixes the overwrite issue that was proposed by users.

### Introduction
The behaviour of overwriting is controlled by two factors: (1) the default values set in `pspm_options`; (2) the checking in `pspm_overwrite`. However, some functions that call `pspm_overwrite` are not overwriting files properly, because the returned values from `pspm_overwrite` were not only the overwriting marker but also the status marker that is used as a general rule in PsPM. This pull request is therefore fixing the behaviour of `pspm_overwrite`.

### Method
The expected behaviour of `pspm_overwrite` is to always overwrite if no corresponding file exists in the path.

### Results
The return value of `pspm_overwrite` is called and used for determine whether to overwrite files. This is corrected for 
* `con2`: line 76---77
* `data_editor`: line 202---203
* `get_marker_info`: line 80---81
* `import`: line 308---309
* `segment_mean`: line 157---158
Also, the default value of overwrite for `pspm_import` has been updated to `1` from `0`.