### PR TITLE
Fix issue 500 -- pspm_interp1

### DIFF
--- a/src/pspm_cfg/pspm_cfg_sf.m
+++ b/src/pspm_cfg/pspm_cfg_sf.m
@@ -195,7 +195,7 @@ mrk_chan.val     = {0};
 mrk_chan.num     = [1 1];
 mrk_chan.help    = {['Indicate the marker channel. By default the first marker channel is ' ...
     'assumed to contain the relevant markers.'], ['Markers are only used if you have ' ...
-    'specified the time units as �markers�.']};
+    'specified the time units as "markers".']};
 
 
 %% Timeunits

--- a/src/pspm_interp1.m
+++ b/src/pspm_interp1.m
@@ -25,7 +25,7 @@ switch nargin
     warning('ID:invalid_input','pspm_interp1 accepts up to two arguments');
 end
 %% 2 Check inputs
-switch sum(~isnan(a))
+switch sum(~isnan(X))
   case 0
     % if there are no non-nans, do not process any interpolation, give a
     % warning and return
@@ -43,7 +43,7 @@ switch sum(~isnan(a))
   otherwise
     % if there are less than 10^ non-nan, still perform interpolation,
     % however give a warning and explain the reason
-    non_nan_percentage = sum(~isnan(a))/length(a);
+    non_nan_percentage = sum(~isnan(X))/length(X);
     if non_nan_percentage<0.1
       warning('ID:invalid_input',...
       'Input data contains less than 10% non-NaN. Interpolation can ',... 

--- a/src/pspm_interp1.m
+++ b/src/pspm_interp1.m
@@ -13,6 +13,7 @@ function Y = pspm_interp1(varargin)
 %   Introduced in PsPM 6.1
 %   Written in 2023 by Teddy Chao (UCL)
 
+%% 1 Load inputs
 switch nargin
   case 1
     X = varargin{1};
@@ -23,7 +24,33 @@ switch nargin
   otherwise
     warning('ID:invalid_input','pspm_interp1 accepts up to two arguments');
 end
-% find nan head and tail
+%% 2 Check inputs
+switch sum(~isnan(a))
+  case 0
+    % if there are no non-nans, do not process any interpolation, give a
+    % warning and return
+    warning('ID:invalid_input',...
+      'Input data contains only NaNs thus cannot be interpolated.')
+    Y = X;
+    return
+  case 1
+    % if there are only 1 non-nan, do not process any interpolation,
+    % give a warning and explain the reason
+    warning('ID:invalid_input',...
+      'Input data contains only 1 non-NaN thus cannot be interpolated.')
+    Y = X;
+    return
+  otherwise
+    % if there are less than 10^ non-nan, still perform interpolation,
+    % however give a warning and explain the reason
+    non_nan_percentage = sum(~isnan(a))/length(a);
+    if non_nan_percentage<0.1
+      warning('ID:invalid_input',...
+      'Input data contains less than 10% non-NaN. Interpolation can ',... 
+      'still be performed but results could be inaccurate.')
+    end
+end
+%% 3 find nan head and tail
 X_nan_head = 0;
 X_nan_tail = 0;
 X_nan_head_range = [];

--- a/src/pspm_resp_pp.m
+++ b/src/pspm_resp_pp.m
@@ -85,7 +85,7 @@ filt.hpfreq    = .01;
 filt.hporder   = 1;
 filt.direction = 'bi';
 filt.down      = 10;
-[sts, newresp, newsr] = pspm_prepdata(resp - mean(resp), filt);
+[sts, newresp, newsr] = pspm_prepdata(resp - mean(resp,"omitnan"), filt);
 % Median filter
 newresp = medfilt1(newresp, ceil(newsr) + 1);
 %% detect breathing cycles


### PR DESCRIPTION
### Introduction
Users reported an issue when the input data contains NaNs. The issues is caused by the approach of calculating mean and interpolating at `pspm_resp_pp`, `pspm_prepdata`, `pspm_interp1`. The expected behaviour is listed as below:
1. In `pspm_interp1`, interpolation should be performed if the data contains at least two non-NaN values.
2. Data as the input of `pspm_prepdata` should be carefully checked to avoid being converted into NaNs due to other calculations, for example calculating the mean.
The pull request fixes #500.

### Results
Changes proposed in this pull request:
- Update `pspm_interp1`
  - Add data checking for `pspm_interp1`.
- Update `pspm_resp_pp`
  - Avoid _NaN_ converting when performing mean-based filtering.