### PR TITLE
Fix issue 503 --- pspm_sf relevant functions

### DIFF
--- a/src/pspm_cfg/pspm_cfg_sf.m
+++ b/src/pspm_cfg/pspm_cfg_sf.m
@@ -193,7 +193,7 @@ mrk_chan         = cfg_entry;
 mrk_chan.name    = 'Marker Channel';
 mrk_chan.tag     = 'mrk_chan';
 mrk_chan.strtype = 'i';
-mrk_chan.val     = {0};
+mrk_chan.val     = {1};
 mrk_chan.num     = [1 1];
 mrk_chan.help    = {['Indicate the marker channel. By default the first marker channel is ' ...
     'assumed to contain the relevant markers.'], ['Markers are only used if you have ' ...

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -166,8 +166,8 @@ end
 if strcmpi(model.timeunits, 'whole')
   epochs = repmat({[1 1]}, numel(model.datafile), 1);
 else
-  for iSn = 1:numel(model.datafile)
-    [sts_get_timing, epochs{iSn}] = pspm_get_timing('epochs', model.timing{iSn}, model.timeunits);
+  for iFile = 1:numel(model.datafile)
+    [sts_get_timing, epochs{iFile}] = pspm_get_timing('epochs', model.timing{iFile}, model.timeunits);
     if sts_get_timing == -1
       warning('ID:invalid_input', 'Call of pspm_get_timing failed.');
       return;
@@ -230,7 +230,7 @@ for iFile = 1:numel(model.datafile)
       [~, sortindx] = sort(missing{iFile}(:, 1));
       missing{iFile} = missing{iFile}(sortindx,:);
       % check for overlap and merge
-      for k = 2:size(missing{iSn}, 1)
+      for k = 2:size(missing{iFile}, 1)
         if missing{iFile}(k, 1) <= missing{iFile}(k - 1, 2)
           missing{iFile}(k, 1) =  missing{iFile}(k - 1, 1);
           missing{iFile}(k - 1, :) = [];


### PR DESCRIPTION
### Introduction
Issue #486: Users reported an issue when loading data and running SF analysis.
This pull request attempts to fix the issue #503 for `pspm_sf` and its relevant functions. Users have reported that `pspm_sf` will report errors when processing data whose `time_unit` is defined as `marker`. A series of issues are also discovered and marked during investigating this issue. The results are function-specifically listed below for discussing.

### Method
`pspm_sf` should be updated in line with the last update, i.e. `pspm_sf_dcm` should accept `model` and `options`.

### Results
#### GUI
`SF model` should allow `missing epochs` as an optional field. Now it looks like below.
<img width="882" alt="image" src="https://github.com/bachlab/PsPM/assets/3895146/afe5ba64-8869-4a8d-ba71-98ce84997f46">
In this window, `missing epochs` is an optional field to add. Users can add missing epochs if they need and ignore missing epochs as default if they do not need to. This part is done by updating the functions `pspm_cfg_sf` and `pspm_cfg_run_sf`.

#### src/pspm_cfg/pspm_cfg_run_sf.m
- Line 81--83, adding transferring missing data to the function from GUI.

#### src/pspm_cfg/pspm_cfg_sf.m
- Line 196: the default value for `marker_chan_num` is set to `1`.
- Line 299--319: the missing epoch can be set to none in the GUI if preferred.

#### src/pspm_options.m
-- Line 582: `int` should include 0 as some values need to include 0 as an acceptable value. Further refinement can be done for some parameters by adding more field checking code in the corresponding functions.

#### src/pspm_overwrite.m
- Line 99--100: There should be a default return value as `pspm_overwrite` is not expected to be a void function.

#### src/pspm_sf.m
- Line 169 etc
  - `iSn` is replaced by `iFile` as it denotes the number of datafile.
- Line 204
  - It is more robust to specify the corresponding `.overwrite` in the code.
- Section 3.6, Line 244--252
  - The logic of loading data based on the setting of `options.marker_chan_num` has been updated.
    - `model.datafile` is now loaded from the corresponding session `iFile`
  - `events` will be loaded based on the loaded `ndata`.
- Line 264
  - `epochs` has been updated to the corresponding `iFile` session.

#### src/pspm_sf_auc.m
`pspm_sf_auc` should be in line with `pspm_sf_dcm` in terms of its input.

#### src/pspm_sf_mp.m
* `pspm_sf_mp` should be in line with `pspm_sf_dcm` in terms of its input.
* Line 172--174
  * The initial values of `a`, `asp` and `ind` have been set up.

#### src/pspm_sf_scl.m
`pspm_sf_scl` should be in line with `pspm_sf_dcm` in terms of its input.