### PR TITLE
Fix issue 514

### DIFF
--- a/src/pspm_version.m
+++ b/src/pspm_version.m
@@ -60,10 +60,10 @@ if nargin > 0
               sprintf('Latest version : %s\n', new_v)]);
           end
         else
-          warning('ID:invalid_input', 'Cannot figure out if there is a new version.'); return;
+          warning('ID:invalid_input', 'Cannot figure out if there is a new version.');
         end
       catch
-        warning('ID:invalid_input', 'Cannot check for updates.'); return
+        warning('ID:invalid_input', 'Cannot check for updates.');
       end
   end
 end


### PR DESCRIPTION
Fixes #514.

## Introduction
The issue appears as PsPM cannot be started when it is called offline. The reason of this issue is, at line 63 and 66 the script is terminated if it is offline, which will not assign values to the expected values `sts` and `version_of_pspm`.

## Method
Under the offline situation, the variables `sts` and `version_of_pspm` should be still assigned in `pspm_version`, before the script `pspm_version` is terminated.

## Results
At line 63 and 66, the `return` behaviour is removed, because the return values should be assigned at line 73--79.
The `new_v` is not assigned because version checking cannot be performed.
PsPM can be started when offline with the new code, after testing.

<img width="1336" alt="image" src="https://github.com/bachlab/PsPM/assets/3895146/2f27b0aa-1e39-4a5e-af61-0afcfee3057b">
