### PR TITLE
Fix issue 555 -- pspm_init

### DIFF
--- a/src/pspm.m
+++ b/src/pspm.m
@@ -4,11 +4,25 @@ function pspm(varargin)
 % ● Last Updated in
 %   PsPM 6.1
 % ● History
-%   Written in 13-09-2022 by Teddy Chao (UCL)
+%   Updated 12-2023 by Teddy
 
-if verLessThan('matlab','9.4')
-    pspm_guide
-else
-    pspm_appdesigner
+if ispc
+  if verLessThan('matlab','9.4') % MATLAB 2018
+      pspm_guide
+  else
+      pspm_appdesigner
+  end
+elseif ismac
+  if verLessThan('matlab','9.4') % MATLAB 2018
+      pspm_guide
+  else
+      pspm_appdesigner
+  end
+else % Linux
+  if verLessThan('matlab','9.12') % MATLAB 2022
+      pspm_guide
+  else
+      pspm_appdesigner
+  end
 end
 return


### PR DESCRIPTION
Fixes #555.

The main reason that leads to the issue mentioned by the user is caused by the incompatibility between app designer and older version MATLAB (2018) on Linux. This issue has been fixed in this pull request. Specifically, only newer versions of MATLAB (>2022) on Linux are now using app designer, and the earlier versions are now using GUIDE version.