### PR TITLE
adapt pspm_split_sessions

### DIFF
--- a/test/pspm_split_sessions_test.m
+++ b/test/pspm_split_sessions_test.m
@@ -93,11 +93,15 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
       % 6 minutes data
       pspm_testdata_gen(channels, 60*6, fn);
       newdatafile = pspm_split_sessions(fn, 3, struct());
+      % check number of sessions
       this.verifyEqual(numel(newdatafile), nsessions);
+      % check that all sessions (with the exception of the first) start at the marker onset  
       for i = 1:numel(newdatafile)
         if exist(newdatafile{i}, 'file')
-          [~, ~, d] = pspm_load_data(newdatafile{i});
-          this.verifyEqual(d{3}.data(1), 0);
+          if i > 1
+            [~, ~, d] = pspm_load_data(newdatafile{i});
+            this.verifyEqual(d{3}.data(1), 0);
+          end
           delete(newdatafile{i});
         end
       end
@@ -168,8 +172,10 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
       for i = 1:numel(newdatafile)
         if exist(newdatafile{i}, 'file')
           % test suffix and prefix
-          [~, info, ~] = pspm_load_data(newdatafile{i});
-          this.verifyEqual(info.duration, sess_dur(i), 'RelTol', 0.5);
+          if i > 1 && i < numel(newdatafile)
+              [~, info, ~] = pspm_load_data(newdatafile{i});
+              this.verifyEqual(info.duration, sess_dur(i), 'RelTol', 0.5);
+          end
           % remove file
           delete(newdatafile{i});
         end

--- a/test/pspm_split_sessions_test.m
+++ b/test/pspm_split_sessions_test.m
@@ -163,8 +163,10 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
       end
       % adapt the first and last session duration, as no trimming will be
       % performed towards file start/end
-      sess_dur(1) = split_times(1);
-      sess_dur(end) = dur - split_times(end);
+      if ~isempty(splitpoints)
+        sess_dur(1) = split_times(1);
+        sess_dur(end) = dur - split_times(end);
+      end
       options.splitpoints = splitpoints;
       newdatafile = pspm_split_sessions(fn, 3, options);
       if ~isempty(splitpoints)

--- a/test/pspm_split_sessions_test.m
+++ b/test/pspm_split_sessions_test.m
@@ -161,6 +161,10 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
         ends = [split_times dur];
         sess_dur = diff([starts; ends]);
       end
+      % adapt the first and last session duration, as no trimming will be
+      % performed towards file start/end
+      sess_dur(1) = split_times(1);
+      sess_dur(end) = dur - split_times(end);
       options.splitpoints = splitpoints;
       newdatafile = pspm_split_sessions(fn, 3, options);
       if ~isempty(splitpoints)
@@ -171,11 +175,9 @@ classdef pspm_split_sessions_test < matlab.unittest.TestCase
       this.verifyEqual(numel(newdatafile),n_sess_exp);
       for i = 1:numel(newdatafile)
         if exist(newdatafile{i}, 'file')
-          % test suffix and prefix
-          if i > 1 && i < numel(newdatafile)
-              [~, info, ~] = pspm_load_data(newdatafile{i});
-              this.verifyEqual(info.duration, sess_dur(i), 'RelTol', 0.5);
-          end
+          % test session duration
+          [~, info, ~] = pspm_load_data(newdatafile{i});
+          this.verifyEqual(info.duration, sess_dur(i), 'RelTol', 0.5);
           % remove file
           delete(newdatafile{i});
         end


### PR DESCRIPTION
Fixes #563 .

Changes proposed in this pull request:
- avoids markers being dropped in secondary marker channels before first or after last marker of primary channel during pspm_split_sessions
- as a consequence, no trimming is done for the first and last session
