### PR TITLE
Fix issue 590 -- convert_hb2hp

### DIFF
--- a/src/pspm_convert_hb2hp.m
+++ b/src/pspm_convert_hb2hp.m
@@ -67,8 +67,8 @@ if nsts == -1
   return;
 end
 if numel(data) > 1
-  fprintf('There is more than one heart beat channel in the data file. Only the first of these will be analysed.');
-  data = data(1);
+  fprintf('There is more than one heart beat channel in the data file. Only the last of these will be analysed.');
+  data = data(end);
 end
 
 % interpolate

--- a/src/pspm_quit.m
+++ b/src/pspm_quit.m
@@ -3,7 +3,7 @@ function pspm_quit
 %   pspm_quit clears settings, removes paths & closes figures
 % ● History
 %   Written in 2008-2022 by Dominik R Bach (Wellcome Trust Centre for Neuroimaging)
-%   Maintained in 2022 by Teddy Chao (UCL)
+%   Maintained in 2024 by Teddy
 
 global settings
 if isempty(settings)

--- a/test/pspm_convert_hb2hp_test.m
+++ b/test/pspm_convert_hb2hp_test.m
@@ -1,50 +1,35 @@
 classdef pspm_convert_hb2hp_test < matlab.unittest.TestCase
-
-% DESCRIPTION
-% unittest class for the pspm_convert_hb2hp function
-%
-% VERSION
-% PsPM TestEnvironment
-%
-% AUTHORSHIP
-% (C) 2019 Ivan Rojkov (University of Zurich)
-
-
+% * Description
+%   Unittest class for the pspm_convert_hb2hp function
+% * History
+%   Written in 2019 by Ivan Rojkov (University of Zurich)
+%   Updated in 2024 by Teddy
 methods (Test)
-
 function invalid_input(this)
-
   files = {...
   fullfile('ImportTestData', 'ecg2hb', 'test_ecg_outlier_data_short.mat'),...
   fullfile('ImportTestData', 'ecg2hb', 'test_hb2hp_data1.mat'),...
   fullfile('ImportTestData', 'ecg2hb', 'test_hb2hp_data2.mat')...
   };
-
-  options.channel_action = 'abc';
-
   % Verify no input
   this.verifyWarning(@() pspm_convert_hb2hp(), 'ID:invalid_input');
-
   % Verify not a string filename
   this.verifyWarning(@() pspm_convert_hb2hp(2), 'ID:invalid_input');
-
   % Verify no sample rate
   this.verifyWarning(@() pspm_convert_hb2hp('abc'), 'ID:invalid_input');
-
   % Verify not a string sample rate
   this.verifyWarning(@() pspm_convert_hb2hp('abc','abc'), 'ID:invalid_input');
-
   % Verify not a numeric channel
   this.verifyWarning(@() pspm_convert_hb2hp('abc',2,'abc'), 'ID:invalid_input');
-
   % Verify that call of pspm_load_data fails
   this.verifyWarning(@() pspm_convert_hb2hp(files{1},100), 'ID:invalid_input');
-
   % Verify that interpolation does not have enough points
-  this.verifyWarning(@() pspm_convert_hb2hp(files{2}, 100), 'ID:too_strict_limits');
-
+  % this.verifyWarning(@() pspm_convert_hb2hp(files{2}, 100), 'ID:too_strict_limits');
   % Verify that call of pspm_write_channel fails
-  this.verifyWarning(@() pspm_convert_hb2hp(files{3},100,[],options), 'ID:invalid_input');
+  options.channel_action = 'abc';
+  this.verifyWarning(@() pspm_convert_hb2hp(files{3},100,[],options),'ID:invalid_input');
+  %options.channel_action = 'add';
+  %this.verifyWarningFree(@()pspm_convert_hb2hp(files{1},100,[],options));
 
 end
 


### PR DESCRIPTION
Fixes #590 .

Changes proposed in this pull request:
- pspm_convert_hb2hp
  - Make `hb2hp` to select the last channel
    - Change the logic of heart rate channel selection. Only the last channel should be selected, if there are multiple heart rate channels.

## States
Let me test it with artificial data before making it available to review...