### PR TITLE
fix bug in DCM

### DIFF
--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -361,7 +361,7 @@ foo = {};
 for vs = 1:numel(valid_subsessions)
   isbSn = valid_subsessions(vs);
   sbSn = subsessions(isbSn, :);
-  flanks = pspm_time2index(sbSn(2:3), data{sbSn(1)}{1}.header.sr);
+  flanks = pspm_time2index(sbSn(2:3), sr{sbSn(1)});
   sbSn_data = y{sbSn(1)}(flanks(1):flanks(2));
   sbs_miss = isnan(sbSn_data);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- fix a bug that could lead to a wrong sample rate being used if more than one SCR channel existed in the file, and they had different sample rate 
- specifically, this line of code erroneously used the sample rate of the **first** retrieved SCR channel, but the data from the **last** should be used
- this is urgent and should be included in the upcoming hotfix
