### PR TITLE
fix bug in selection of marker channel in pspm_glm

### DIFF
--- a/src/pspm_glm.m
+++ b/src/pspm_glm.m
@@ -199,7 +199,7 @@ for iFile = 1:nFile
     % first marker_channel is used
     events{iFile} = data{1}.data(:) * data{1}.header.sr;
     if strcmp(model.timeunits,'markervalues')
-      model.timing{iFile}.markerinfo = data{end}.markerinfo;
+      model.timing{iFile}.markerinfo = data{1}.markerinfo;
     end
   end
 end


### PR DESCRIPTION
# Proposed changes
- fix a bug in pspm_glm that leads to markers being taken from the first marker channel, but markervalues from the last
- this is urgent and should be included in the upcoming hotfix