### PR TITLE
fix overwriting in data editor

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -199,7 +199,7 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        ow = pspm_overwrite(out_file);
+        ow = pspm_overwrite(out_file, handles.options.overwrite);
         if ow
           save(out_file, 'epochs');
         end


### PR DESCRIPTION
Fixes a user-reported bug in overwriting existing files in `pspm_data_editor`. 

