### PR TITLE
several bugfixes

### DIFF
--- a/src/pspm_convert_ecg2hb.m
+++ b/src/pspm_convert_ecg2hb.m
@@ -7,9 +7,6 @@ function [sts,infos] = pspm_convert_ecg2hb(fn, options)
 %   sts = pspm_convert_ecg2hb(fn, options)
 % ● Arguments
 %                 fn: data file name
-%            channel: number of ECG channel (optional, default: last ECG
-%                     channel) if is empty (= 0 / []) then default channel will
-%                     be used.
 %   ┌─────── options
 %   ├───────.channel: [optional, numeric/string, default: 'ecg', i.e. last 
 %   │                 ECG channel in the file]

--- a/src/pspm_dcm_inv.m
+++ b/src/pspm_dcm_inv.m
@@ -834,13 +834,13 @@ if ~options.getrf
       eTheta(trl).a = newzfactor .* exp(eTheta(trl).a) ./ eSCR_unit;
     end
 
-    for trl = 1:size(sfTheta)
+    for trl = 1:numel(sfTheta)
       % SF response function includes a parameter for the amplitude of an
       % SN burst that causes a 1 mcS response, see pspm_sf_get_theta
       sfTheta(trl).a = newzfactor * exp(sfTheta(trl).a) * sf_unit;
     end
 
-    for trl = 1:size(SCLtheta)
+    for trl = 1:numel(SCLtheta)
       if scl_ln(trl) > 0
         sig.G0 = scl_ln(trl);
         SCLtheta(trl).t = scl_lb(trl) + sigm(SCLtheta(trl).t, sig);

--- a/src/pspm_extract_segments.m
+++ b/src/pspm_extract_segments.m
@@ -154,7 +154,7 @@ if options.norm
   newmat = cell2mat(data_raw(:));
   zfactor = std(newmat(:));
   offset  = mean(newmat(:));
-  for iSn = 1:n_sessions
+  for iSn = 1:numel(data_raw)
     data_raw{iSn} = (data_raw{iSn} - offset) / zfactor;
   end
 end

--- a/src/pspm_find_valid_fixations.m
+++ b/src/pspm_find_valid_fixations.m
@@ -212,16 +212,22 @@ if ~strcmpi(options.channel, 'both')
                     warning('ID:invalid_input', 'Failed to convert data.');
                     return
                   end
+             else
+                x_data = gaze_x.data;
+                x_range = gaze_x.header.range;
              end
              if ~strcmpi(y_unit,'mm')
-                [nsts,y_data] = pspm_convert_unit(gaze_y.data, y_unit, 'mm');
-                [msts,y_range] = pspm_convert_unit(transpose(gaze_y.header.range), y_unit, 'mm');
-                  if nsts~=1 || msts~=1
-                    warning('ID:invalid_input', 'Failed to convert data.');
-                    return
-                  end
-             end            
-         
+                 [nsts,y_data] = pspm_convert_unit(gaze_y.data, y_unit, 'mm');
+                 [msts,y_range] = pspm_convert_unit(transpose(gaze_y.header.range), y_unit, 'mm');
+                 if nsts~=1 || msts~=1
+                     warning('ID:invalid_input', 'Failed to convert data.');
+                     return
+                 end
+             else
+                 y_data = gaze_y.data;
+                 y_range = gaze_y.header.range;
+             end
+
             % convert normalized fixation points to data resolution
             fix_point_temp = zeros(size(fix_point));
             fix_point_temp(:,1) = x_range(1)+ fix_point(:,1)* diff(x_range);


### PR DESCRIPTION
1. Fixes a bug in `pspm_extract_sessions` that only occurs under a specific option.
2. Fixes a bug in `pspm_find_valid_fixations` when gaze channel is in correct units
3. Fixes a bug in `pspm_dcm_inv` which could be handled by matlab until R2024a.
4. Fixes #685: a bug in help text of `pspm_convert_ecg2hb`