### PR TITLE
Fix issue 718 -- `display`

### DIFF
--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -29,7 +29,7 @@ gui_State = struct('gui_Name',       mfilename, ...
   'gui_LayoutFcn',  [], ...
   'gui_Callback',   []);
 if nargin && ischar(varargin{1})
-  gui_State.gui_Callback = str2func(varargin{1});
+  gui_State.gui_Callback = varargin{1};
 end
 
 if nargout

--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -2,12 +2,18 @@ function varargout = pspm_display(varargin)
 % ● Description
 %   pspm_display is the code for the GUI that is used to display different data from scr
 %   datafiles.
+% ● Format
+%   pspm_display
+%   pspm_display(filename), such as pspm_display('test.mat')
+%   pspm_display(filepath), such as pspm_display('~/Documents/test.mat')
 % ● Arguments
-%   Accepts input: 'filepath/filename'
+%   filename: the name of a file to be displayed, which must ends with '.mat'.
+%   filepath: the path of a file to be displayed, which must ends with '.mat'.
 % ● History
 %   Introduced in PsPM 3.0
 %   Written in 2013 Philipp C Paulus (Technische Universitaet Dresden)
-%   Maintained in 2021 by Teddy Chao (UCL)
+%   Maintained in 2021 by Teddy
+%   Bug fixed in 2024 by Teddy
 
 %% Initialise
 global settings
@@ -29,7 +35,11 @@ gui_State = struct('gui_Name',       mfilename, ...
   'gui_LayoutFcn',  [], ...
   'gui_Callback',   []);
 if nargin && ischar(varargin{1})
-  gui_State.gui_Callback = varargin{1};
+  if nargin == 1 && length(varargin{1})>5 && strcmp(varargin{1}(end-3:end), '.mat')
+    gui_State.gui_Callback = varargin{1};
+  else
+    gui_State.gui_Callback = str2func(varargin{1});
+  end
 end
 
 if nargout


### PR DESCRIPTION
Fixes #718 

### Cause of the issue
The issue happened at line 32 in `pspm_display`. This is a line that is iteratively used when `pspm_display` is running. Initially, the `varargin` is set to be the input of `pspm_display`. In default, `varargin` is empty, so the line is not actually executed. In the next iteration, `varargin` becomes a multi-cell cell array, which is when `nargin` is no longer 0. This will not consider the situation that `pspm_display` actually has an input.
I am not fully clear what `gui_State.gui_Callback` is used for, since it is not really called much in this function. Therefore, I set a situation to identify whether it is processing the user's input as `varargin`, and this situation is determined in line 38 of the new version.

### Changes proposed in this pull request:
- This pull request updates the checking of input variable for display. If the `varargin{1}` refers to user's input, as a file name or a file path, it will no longer call `str2func`. The situation for determining the input is a file name or a file path is that the `varargin{1}` ends with `.mat`.