### PR TITLE
Fix issue 717 -- `data_editor`

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -28,7 +28,8 @@ function varargout = pspm_data_editor(varargin)
 % ● History
 %   Introduced in PsPM 3.1
 %   Written in 2015 by Tobias Moser (University of Zurich)
-%   Maintained in 2021 by Teddy Chao (UCL)
+%   Maintained in 2021 by Teddy
+%   Updated in 2024 by Teddy for UI controller display
 
 % Begin initialization code - DO NOT EDIT
 gui_Singleton = 1;

--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -99,13 +99,12 @@ if numel(varargin) > 1 && isstruct(varargin{2}) % load options
   if handles.options.invalid
     return
   end
-  if isfield(handles.options, 'output_file') && ... % check if options are valid and assign accordingly
-      ischar(handles.options.output_file)
+  if isfield(handles.options, 'output_file') && ischar(handles.options.output_file)
+    % check if options are valid and assign accordingly  
     handles.output_file = handles.options.output_file;
     set(handles.edOutputFile, 'String', handles.output_file);
   end
-  if isfield(handles.options, 'epoch_file') && ...
-      ischar(handles.options.epoch_file)
+  if isfield(handles.options, 'epoch_file') && ischar(handles.options.epoch_file)
     handles.epoch_file = handles.options.epoch_file;
     set(handles.edOpenMissingEpochFilePath, 'String', handles.epoch_file);
   end
@@ -129,9 +128,10 @@ if numel(varargin) > 0
   handles = guidata(hObject);
   guidata(hObject, handles);
   PlotData(hObject);
-  if isfield(handles, 'options') && isfield(handles.options, 'output_file')
-    set(handles.pnlOutput, 'Visible', 'off');
-  end
+  % % enable the following code if output file module wants to be enabled
+  % if isfield(handles, 'options') && isfield(handles.options, 'output_file')
+  %   set(handles.pnlOutput, 'Visible', 'off');
+  % end
   if isfield(handles, 'options') && ~isfield(handles.options, 'epoch_file')
     set(handles.pnlEpoch, 'Visible', 'off');
   end

--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -132,9 +132,9 @@ if numel(varargin) > 0
   % if isfield(handles, 'options') && isfield(handles.options, 'output_file')
   %   set(handles.pnlOutput, 'Visible', 'off');
   % end
-  if isfield(handles, 'options') && ~isfield(handles.options, 'epoch_file')
-    set(handles.pnlEpoch, 'Visible', 'off');
-  end
+  % if isfield(handles, 'options') && ~isfield(handles.options, 'epoch_file')
+  %   set(handles.pnlEpoch, 'Visible', 'off');
+  % end
   if isfield(handles, 'options') && isfield(handles.options, 'epoch_file')
     handles.epoch_file = handles.options.epoch_file;
     Add_Epochs(hObject, handles)


### PR DESCRIPTION
Fixes #717.

The issue was caused by the settings of UI component display. The settings of displaying `echo file` component and `output file` component are managed at lines 131 to 136 in `pspm_data_editor`. The lines functioned as following:

* If users call the GUI directly without specifying `options` in command, it will always display `echo file` and `output file`.
* If users call the GUI with specifying `options`, it will only display `output_file` when users have *not* specified `output_file`, and will only display `epoch_file` if users *have* specified `epoch_file`.

I am not fully clear why the logic was set to be like this. I think maybe we can discuss about how we want to set this. Currently I have disabled these customisations, so the two `epoch_file` and `output_file` modules will always be displayed no matter how users specify options subfields.
