### PR TITLE
Update pspm_display.m

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -180,7 +180,7 @@ else
           end
         end
         if write_file
-          newd.options.overwrite = pspm_overwrite(out_file, options);
+          newd.options.overwrite = pspm_overwrite(out_file, 1);
           [write_success, ~, ~] = pspm_load_data(out_file, newd);
           if disp_success
             if write_success
@@ -200,7 +200,7 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        ow = pspm_overwrite(out_file, handles.options.overwrite);
+        ow = pspm_overwrite(out_file, 1);
         if ow
           save(out_file, 'epochs');
         end

--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -180,7 +180,7 @@ else
           end
         end
         if write_file
-          newd.options.overwrite = pspm_overwrite(out_file, 1);
+          newd.options.overwrite = pspm_overwrite(out_file, options);
           [write_success, ~, ~] = pspm_load_data(out_file, newd);
           if disp_success
             if write_success
@@ -200,7 +200,7 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        ow = pspm_overwrite(out_file, 1);
+        ow = pspm_overwrite(out_file, handles.options.overwrite);
         if ow
           save(out_file, 'epochs');
         end

--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -488,8 +488,6 @@ if not(sts == 0)
   set(handles.button_autoscale,'Value',0);
   set(handles.button_all,'Value',1);
 
-elseif numel(varargin)>1
-  warning('Too many input arguments. Inputs 2:end ignored. ');
 end
 
 % Update handles structure

--- a/src/pspm_glm_recon.m
+++ b/src/pspm_glm_recon.m
@@ -35,7 +35,7 @@ bfdur = size(bs, 1);
 
 % for ra_fc with bf.arg == 1 take regressor difference
 % -------------------------------------------------------------------------
-if strcmpi('ra_fc', glm.modelspec) && glm.bf.args == 1
+if strcmpi('ra_fc', glm.modelspec) && ~isempty(glm.bf.args) && glm.bf.args == 1
   regdiff = 1;
 else
   regdiff = 0;

--- a/src/pspm_rev_glm.m
+++ b/src/pspm_rev_glm.m
@@ -6,7 +6,6 @@ function varargout = pspm_rev_glm(modelfile, plotNr)
 %   fig = pspm_rev_glm(modelfile, plotNr)
 % ● Arguments
 %   * modelfile : filename and path of modelfile
-%   *       glm : loaded model
 %   *    plotNr : defines which figure shall be plotted
 %                 (several plots can be defined by a vector)
 %                 1 - design matrix, SPM style

--- a/src/pspm_review.m
+++ b/src/pspm_review.m
@@ -194,8 +194,7 @@ set(handles.textStatus,'String','Plotting is in progress. Please wait...');
 switch handles.modelData{handles.currentModel}.modeltype
   case 'glm'
     handles.modelData{handles.currentModel}.fig = ...
-      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, ...
-      handles.modelData{handles.currentModel}.model, 1);
+      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, 1);
 
   case 'dcm'
     sessionNr = checkSessionNr(handles);
@@ -228,8 +227,7 @@ set(handles.textStatus,'String','Plotting is in progress. Please wait...');
 switch handles.modelData{handles.currentModel}.modeltype
   case 'glm'
     handles.modelData{handles.currentModel}.fig = ...
-      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, ...
-      handles.modelData{handles.currentModel}.model, 2);
+      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, 2);
 
   case 'dcm'
     sessionNr = checkSessionNr(handles);
@@ -257,8 +255,7 @@ set(handles.textStatus,'String','Plotting is in progress. Please wait...');
 switch handles.modelData{handles.currentModel}.modeltype
   case 'glm'
     handles.modelData{handles.currentModel}.fig = ...
-      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, ...
-      handles.modelData{handles.currentModel}.model, 3);
+      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, 3);
 
   case 'dcm'
     sessionNr = checkSessionNr(handles);
@@ -280,8 +277,7 @@ set(handles.textStatus,'String','Plotting is in progress. Please wait...');
 switch handles.modelData{handles.currentModel}.modeltype
   case 'glm'
     handles.modelData{handles.currentModel}.fig = ...
-      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, ...
-      handles.modelData{handles.currentModel}.model, 4);
+      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, 4);
   case 'dcm'
     pspm_rev_dcm(handles.modelData{handles.currentModel}.model, 'names');
 end
@@ -298,8 +294,7 @@ set(handles.textStatus,'String','Plotting is in progress. Please wait...');
 switch handles.modelData{handles.currentModel}.modeltype
   case 'glm'
     handles.modelData{handles.currentModel}.fig = ...
-      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, ...
-      handles.modelData{handles.currentModel}.model, 5);
+      pspm_rev_glm(handles.modelData{handles.currentModel}.modelfile, 5);
   case 'dcm'
     handles.modelData{handles.currentModel}.fig = ...
       pspm_rev_con(handles.modelData{handles.currentModel}.model);


### PR DESCRIPTION
Fixes #744.

> When a file is selected and I click on "done", the following error occurs (and the file selector remains frozen).

Cannot be replicated here... The function can run successfully.

> When I close the file selector by clicking on the top-left cross, the following error message occurs

This is caused by the invalid usage of `varargin` at line 491--492 in `pspm_display`. That line of code is not really usable because `varargin` is not available inside `load_Callback`. This error has been fixed by removing these two lines.

> Same error for pspm_review in develop branch, using models that were computed by the same version.

The issue is caused by unuqdated `pspm_rev_glm `. In `pspm_review`, it calls `pspm_rev_glm` by using three variables, but the second variable it calls is no longer needed in `pspm_rev_glm`. This has been updated in `pspm_review` and function description of `pspm_rev_glm`.
