### PR TITLE
Update pspm_data_editor.m

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -180,7 +180,7 @@ else
           end
         end
         if write_file
-          newd.options.overwrite = pspm_overwrite(out_file, options);
+          newd.options.overwrite = pspm_overwrite(out_file, 1);
           [write_success, ~, ~] = pspm_load_data(out_file, newd);
           if disp_success
             if write_success
@@ -200,7 +200,7 @@ else
       ep = cellfun(@(x) x.range', handles.epochs, 'UniformOutput', 0);
       epochs = cell2mat(ep)';
       if strcmpi(handles.input_mode, 'file')
-        ow = pspm_overwrite(out_file, handles.options.overwrite);
+        ow = pspm_overwrite(out_file, 1);
         if ow
           save(out_file, 'epochs');
         end


### PR DESCRIPTION
Fixes #748.

Changes proposed in this pull request:
- The behaviour of overwrite is always set to be true. This is because the two functions will only be called if users want to overwrite. If there has been a file, there will be a dialog that asks users to confirm if they want to replace the current file.

<img width="273" alt="image" src="https://github.com/user-attachments/assets/80c10804-6dfc-4bc7-a0b6-1f377d71cd26">
