### PR TITLE
Update `pspm_help`

### DIFF
--- a/src/pspm_help.m
+++ b/src/pspm_help.m
@@ -12,6 +12,16 @@ function information = pspm_help(mfile)
 %   Introduced in PsPM 6.0
 %   Written in 2022 and updated in 2024 by Teddy
 
+% initial checking
+if isempty(mfile)
+  warning('The file does not exist');
+  return
+elseif length(mfile)<2 && ~strcmp(mfile(end-1:end),'.m')
+  warning('The file does not exist');
+  return
+elseif ~strcmp(mfile(end-1:end),'.m')
+  mfile = [mfile,'.m'];
+end
 fid = fopen(mfile,'r','n','UTF-8');
 % read the file into a cell array, one cell per line
 i = 1;
@@ -30,6 +40,7 @@ A = A(1:find(cellfun(@isempty,A),1)-1);
 A = A(cellfun(@ischar,A) & ~cellfun(@isempty,A));
 % find matching lines
 B = regexp(A,'^\s*%.*','match');
+B = remove_annotation(B);
 B = vertcat(B{:});
 information = sort_info (B);
 if isfield(information, 'Description')
@@ -203,3 +214,13 @@ if ~isempty(B)
     B(end+1) = '.';
   end
 end
+
+function B = remove_annotation(A)
+  marks = ones(1,length(A));
+  for iA = 1:length(A)
+    content = A{iA};
+    if ~isempty(content)
+      markers(iA) = ~contains(content,'//');
+    end
+  end
+  B = A(markers);

--- a/src/pspm_help.m
+++ b/src/pspm_help.m
@@ -151,7 +151,18 @@ for i_level = 1:length(levels)
       fieldname = C(1:(split-1));
       fieldcontent = C((split+1):end);
     end
-    args.(sort_content(fieldname)) = sort_content(fieldcontent);
+    % currently only two levels of arguments are supported, could be
+    % expanded in the future.
+    if contains(sort_content(fieldname), '.')
+      temp = sort_content(fieldname);
+      level1fieldname = temp(1:find(temp=='.')-1);
+      level2fieldname = temp(find(temp=='.')+1:end);
+      args.(level1fieldname).(level2fieldname) = sort_content(fieldcontent);
+    else
+      level1fieldname = sort_content(fieldname);
+      level2fieldname = [];
+      args.(level1fieldname) = sort_content(fieldcontent);
+    end
   else
     [var_name_start,var_name_end] = regexp(C,'(?<=^)(.*?)(?=:)'); % get subfields
     [var_name_start2,var_name_end2] = regexp(C,'(?<=:)(.*?)(?=$)'); % get explainations
@@ -163,7 +174,11 @@ for i_level = 1:length(levels)
     while strcmp(content(1),' ')
       content = content(2:end);
     end
-    args.(sort_content(fieldname)).(sort_content(varname)) = sort_content(content);
+    if ~isempty(level2fieldname)
+      args.(level1fieldname).(level2fieldname).(sort_content(varname)) = sort_content(content);
+    else
+      args.(sort_content(fieldname)).(sort_content(varname)) = sort_content(content);
+    end
   end
 end
 

--- a/src/pspm_process_illuminance.m
+++ b/src/pspm_process_illuminance.m
@@ -25,16 +25,16 @@ function [sts, out] = pspm_process_illuminance(ldata, sr, options)
 %   │                 Define whether to overwrite existing output files or not.
 %   │                 Default value: determined by pspm_overwrite.
 %   ├──────.transfer: Params for the transfer function
-%   └┬───────────.bf: Settings for the basis functions.
-%    ├┬.constriction: Options to the constriction response function.
-%    │└─────.fhandle: Function handle to the constriction response function.
-%    │                The allowed values are @pspm_bf_lcrf_gm.
-%    ├┬────.dilation: Options for the dilation basis function.
-%    │└─────.fhandle: Function handle to the dilation response function.
-%    │                The allowed values are @pspm_bf_ldrf_gm and
-%    │                @pspm_bf_ldrf_gu.
-%    ├─────.duration: Duration of the basis functions in second.
-%    └───────.offset: Offset in second.
+%   └────────────.bf: Settings for the basis functions, described as following.
+%   ┌─────options.bf 
+%   ├──.constriction: Options to the constriction response function. It has a field
+%   │                 ".fhandle" that handles to the constriction response function, 
+%   │                 and its allowed values are @pspm_bf_lcrf_gm.
+%   ├──────.dilation: Options for the dilation basis function. It has a field ".fhandle" 
+%   │                 that handle to the dilation response function, and its allowed 
+%   │                 values are @pspm_bf_ldrf_gm and @pspm_bf_ldrf_gu.
+%   ├──────.duration: Duration of the basis functions in second.
+%   └────────.offset: Offset in second.
 % ● Outputs
 %   *            sts: status
 %   *            out: has same size as ldata and contains either the

--- a/src/pspm_pupil_pp_options.m
+++ b/src/pspm_pupil_pp_options.m
@@ -10,98 +10,107 @@ function [sts, default_settings] = pspm_pupil_pp_options()
 % ● Format
 %   [sts, default_settings] = pspm_pupil_pp_options()
 % ● Outputs
-%   * default_settings: Structure with the fields below.
-%   ▶︎ Allowable values criteria
-%   * raw.PupilDiameter_Min:  Minimum allowable pupil size. Pupil values less
-%                             than this value will be marked as invalid.
-%                             (Default: 1.5)
-%   * raw.PupilDiameter_Max:  Maximum allowable pupil size. Pupil values
-%                             greater than thin value will be markes as invalid.
-%                             (Default: 9.0)
-%   ▶︎ Isolated sample filter criteria
-%       // 'Sample-islands' are clusters of samples that are temporally
-%       // seperated from other samples.
-%   * raw.islandFilter_islandSeperation_ms:
-%                             Minimum distance used to consider samples
-%                             'separated'. (Default: 40 ms)
-%   * raw.islandFilter_minIslandWidth_ms:
-%                             Minimum temporal width required to still consider
-%                             a sample island valid. If the temporal width of
-%                             the island is less than this value, all the
-%                             samples in the island will be marked as invalid.
-%                             (Default: 50 ms)
-%   ▶︎ Dilation speed filter criteria
-%   * raw.dilationSpeedFilter_MadMultiplier:
-%                             Number of medians to use as the cutoff threshold
-%                             when applying the speed filter. (Default: 16)
-%   * raw.dilationSpeedFilter_maxGap_ms:
-%                             Only calculate the speed when the gap between
-%                             samples is smaller than this value.
-%                             (Default: 200 ms)
-%   ▶︎ Edge removal filter criteria
-%       // Sometimes gaps in the data after the dilation speed filter feature
-%       // artifacts at their edges. These artifacts are not always removed by
-%       // the dilation speed filter; as such, samples arounds these gaps may
-%       // also need to be marked as invalid. The settings below indicate when a
-%       // section of missing data is classified as a gap (samples around these
-%       // gaps are in turn rejected).
-%   * raw.gapDetect_minWidth: Minimum width of a missing data section that
-%                             causes it to be classified as a gap.
-%                             (Default: 75 ms)
-%   * raw.gapDetect_maxWidth: Maximum width of a missing data section that
-%                             causes it to be classified as a gap.
-%                             (Default: 2000 ms)
-%   * raw.gapPadding_backward:The section right before the start of a gap
-%                             within which samples are to be rejected.
-%                             (Default: 50 ms)
-%   * raw.gapPadding_forward: The section right after the end of a gap within
-%                             which samples are to be rejected. (Default: 50 ms)
-%   ▶︎ Deviation filter criteria
-%       // At this point a subset of the original samples are marked as valid.
-%       // These samples are the input for this filter. The dilation speed
-%       // filter will not reject samples that do not feature outlying speeds,
-%       // such as is the case when these samples are clustered together. As
-%       // such, a deviation from a smooth trendline filter is warranted.
-%   * raw.residualsFilter_passes:
-%                             Number of passes the deviation filter makes.
-%                             (Default: 4)
-%   * raw.residualsFilter_MadMultiplier:
-%                             The multiplier used when defining the threshold.
-%                             Threshold equals this multiplier times the median.
-%                             After each pass, all the input samples that are
-%                             outside the threshold are removed. Note that all
-%                             samples (even the ones which may have been
-%                             rejected by the previous devation filter pass)
-%                             are considered. (Default: 16)
-%   ▶︎
-%       // At each pass, a smooth continuous trendline is generated using the
-%       // data below, from which the deviation is than calculated and used as
-%       // the filter criteria. The below computation is performed:
-%       // [lowpassB, lowpassA] = butter(1, lowpassCF/(interpFs/2));
-%   * raw.residualsFilter_interpFs:
-%                             Fs for first order Butterworth filter.
-%                             (Default: 100 Hz)
-%   * raw.residualsFilter_lowpassCF:
-%                             Cutoff frequency for first order Butterworth
-%                             filter. (Default: 16 Hz)
-%   ▶︎ Keep filter data
-%   * raw.keepFilterData:     If true, intermediate filter data will be stored.
-%                             Set to false to save memory and improve plotting
-%                             performance. (Default: true)
-%   ▶︎ Final data smoothing
-%   * valid.interp_upsamplingFreq:
-%                             The upsampling frequency used to generate the
-%                             smooth signal. (Default: 1000 Hz)
-%   * valid.LpFilt_cutoffFreq:Cutoff frequency of the lowpass filter used
-%                             during final smoothing. (Default: 4 Hz)
-%   * valid.LpFilt_order:     Filter order of the lowpass filter used during
-%                             final smoothing. (Default: 4)
-%   * valid.interp_maxGap:    Maximum gap in the used (valid) raw samples to
-%                             interpolate over. Sections that were interpolated
-%                             over distances larger than this value will be
-%                             set to NaN. (Default: 250 ms)
+%   *  default_settings: Structure with the fields below.
+%   ┌───────────────raw
+%   │ 
+%   │ // Allowable values criteria
+%   │ 
+%   ├─PupilDiameter_Min:  Minimum allowable pupil size. Pupil values less than 
+%   │                     this value will be marked as invalid. (Default: 1.5)
+%   ├─PupilDiameter_Max:  Maximum allowable pupil size. Pupil values greater than 
+%   │                     thin value will be marked as invalid. (Default: 9.0)
+%   │ 
+%   │ // Isolated sample filter criteria
+%   │ // 'Sample-islands' are clusters of samples that are temporally separated
+%   │ // from other samples.
+%   │ 
+%   ├─islandFilter_islandSeperation_ms:
+%   │                      Minimum distance used to consider samples 'separated'.
+%   │                      (Default: 40 ms)
+%   ├─islandFilter_minIslandWidth_ms:
+%   │                      Minimum temporal width required to still consider
+%   │                      a sample island valid. If the temporal width of the
+%   │                      island is less than this value, all the samples in
+%   │                      the island will be marked as invalid. (Default: 50 ms)
+%   │ 
+%   │ // Dilation speed filter criteria
+%   │ 
+%   ├─dilationSpeedFilter_MadMultiplier:
+%   │                      Number of medians to use as the cutoff threshold
+%   │                      when applying the speed filter. (Default: 16)
+%   ├─dilationSpeedFilter_maxGap_ms:
+%   │                      Only calculate the speed when the gap between samples
+%   │                      is smaller than this value. (Default: 200 ms)
+%   │ 
+%   │ // Edge removal filter criteria
+%   │ // Sometimes gaps in the data after the dilation speed filter feature
+%   │ // artifacts at their edges. These artifacts are not always removed by
+%   │ // the dilation speed filter; as such, samples arounds these gaps may
+%   │ // also need to be marked as invalid. The settings below indicate when a
+%   │ // section of missing data is classified as a gap (samples around these
+%   │ // gaps are in turn rejected).
+%   │ 
+%   ├─gapDetect_minWidth:  Minimum width of a missing data section that causes
+%   │                      it to be classified as a gap. (Default: 75 ms)
+%   ├─gapDetect_maxWidth:  Maximum width of a missing data section that causes
+%   │                      it to be classified as a gap. (Default: 2000 ms)
+%   ├─gapPadding_backward: The section right before the start of a gap within
+%   │                      which samples are to be rejected. (Default: 50 ms)
+%   ├─gapPadding_forward:  The section right after the end of a gap within
+%   │                      which samples are to be rejected. (Default: 50 ms)
+%   │ 
+%   │ // Deviation filter criteria
+%   │ // At this point a subset of the original samples are marked as valid.
+%   │ // These samples are the input for this filter. The dilation speed
+%   │ // filter will not reject samples that do not feature outlying speeds,
+%   │ // such as is the case when these samples are clustered together. As
+%   │ // such, a deviation from a smooth trend-line filter is warranted.
+%   │ 
+%   ├─residualsFilter_passes:
+%   │                      Number of passes the deviation filter makes. 
+%   │                      (Default: 4)
+%   ├─residualsFilter_MadMultiplier:
+%   │                      The multiplier used when defining the threshold.
+%   │                      Threshold equals this multiplier times the median.
+%   │                      After each pass, all the input samples that are
+%   │                      outside the threshold are removed. Note that all
+%   │                      samples (even the ones which may have been rejected
+%   │                      by the previous deviation filter pass) are 
+%   │                      considered. (Default: 16)
+%   │
+%   │ // At each pass, a smooth continuous trend line is generated using the
+%   │ // data below, from which the deviation is than calculated and used as
+%   │ // the filter criteria. The below computation is performed:
+%   │ // [lowpassB, lowpassA] = butter(1, lowpassCF/(interpFs/2));
+%   │ 
+%   ├─residualsFilter_interpFs:
+%   │                      Fs for first order Butterworth filter.
+%   │                      (Default: 100 Hz)
+%   ├─residualsFilter_lowpassCF:
+%   │                      Cutoff frequency for first order Butterworth filter. 
+%   │                      (Default: 16 Hz)
+%   │
+%   │ // Keep filter data
+%   │
+%   └─keepFilterData:      If true, intermediate filter data will be stored.
+%                          Set to false to save memory and improve plotting
+%                          performance. (Default: true)
+%    
+%     // Final data smoothing
+%
+%   ┌───────────────valid
+%   ├interp_upsamplingFreq:The upsampling frequency used to generate the smooth
+%   │                      signal. (Default: 1000 Hz)
+%   ├───LpFilt_cutoffFreq: Cutoff frequency of the lowpass filter used during
+%   │                      final smoothing. (Default: 4 Hz)
+%   ├────────LpFilt_order: Filter order of the lowpass filter used during final
+%   │                      smoothing. (Default: 4)
+%   └───────interp_maxGap: Maximum gap in the used (valid) raw samples to
+%                          interpolate over. Sections that were interpolated
+%                          over distances larger than this value will be set
+%                          to NaN. (Default: 250 ms)
 % ● History
-%   Introduced In PsPM version?.
+%   Introduced In PsPM version ?.
 %   Written in 2019 by Eshref Yozdemir (University of Zurich)
 %   Maintained in 2022 by Teddy
 


### PR DESCRIPTION
Fixes `pspm_help` for second or deeper level subfields.

Changes proposed in this pull request:
- Update `pspm_process_illuminance.m` and `pspm_pupil_pp_options`
- `pspm_help`
  - The input argument of `pspm_help` can be now either `pspm_xxx.m` or `pspm_xxx`.
  - `pspm_help` now supports second level of argument structure, such as `options.bf.offset` in `pspm_process_illuminance`.
  - `pspm_help` now ignores `//` and its following text in the same line for argument description.
