### PR TITLE
fix edge case in marker value import

### DIFF
--- a/src/pspm_get_biosemi.m
+++ b/src/pspm_get_biosemi.m
@@ -64,7 +64,7 @@ for k = 1:numel(import)
     if ~isempty(mrk)
       import{k}.data = [mrk(:).sample];
       import{k}.marker = 'timestamps';
-      import{k}.markerinfo.value = [mrk(:).value];
+      import{k}.markerinfo.value = pspm_struct2vec(mrk, 'value', 'marker');
       import{k}.markerinfo.name = {mrk(:).type};
     else
       import{k}.data = [];

--- a/src/pspm_get_biotrace.m
+++ b/src/pspm_get_biotrace.m
@@ -62,6 +62,7 @@ for k = 1:numel(import)
     import{k}.sr = 1/sr;
     import{k}.marker = 'timestamp';
     import{k}.markerinfo.name = bio.data{end}{import{k}.data};
+    import{k}.markerinfo.name = NaN(numel(import{k}.markerinfo.name), 1);
   else
     import{k}.data = bio.data{1};
     import{k}.sr = sr;

--- a/src/pspm_get_cnt.m
+++ b/src/pspm_get_cnt.m
@@ -67,7 +67,7 @@ for k = 1:numel(import)
     if ~isempty(mrk)
       import{k}.data = [mrk(:).sample];
       import{k}.marker = 'timestamps';
-      import{k}.markerinfo.value = [mrk(:).value];
+      import{k}.markerinfo.value = pspm_struct2vec(mrk, 'value', 'marker');
       import{k}.markerinfo.name = {mrk(:).type};
     else
       import{k}.data = [];

--- a/src/pspm_get_edf.m
+++ b/src/pspm_get_edf.m
@@ -66,7 +66,7 @@ for k = 1:numel(import)
     if ~isempty(mrk)
       import{k}.data = [mrk(:).sample];
       import{k}.marker = 'timestamps';
-      import{k}.markerinfo.value = {mrk(:).value};
+      import{k}.markerinfo.value = pspm_struct2vec(mrk, 'value', 'marker');
       import{k}.markerinfo.name = {mrk(:).type};
     else
       warning('ID:channel_not_contained_in_file', ...

--- a/src/pspm_get_vario.m
+++ b/src/pspm_get_vario.m
@@ -59,7 +59,7 @@ for k = 1:numel(import)
     import{k}.data = [event.time];
     import{k}.marker = 'timestamp';
     import{k}.markerinfo.name = {event.name};
-    import{k}.markerinfo.value = NaN(numel(event.name), 1);
+    import{k}.markerinfo.value = str2double(import{k}.markerinfo.name);
   end
 end
 

--- a/src/pspm_get_vario.m
+++ b/src/pspm_get_vario.m
@@ -59,7 +59,7 @@ for k = 1:numel(import)
     import{k}.data = [event.time];
     import{k}.marker = 'timestamp';
     import{k}.markerinfo.name = {event.name};
-    import{k}.markerinfo.value = {event.name};
+    import{k}.markerinfo.value = NaN(numel(event.name), 1);
   end
 end
 

--- a/src/pspm_struct2vec.m
+++ b/src/pspm_struct2vec.m
@@ -1,0 +1,42 @@
+function v = pspm_struct2vec(S, field, warningtype)
+% ● Description
+%   pspm_struct2vec turns a numerical field in a multi-element structure
+%   array into a numerical vector. If in every element of the structure 
+%   array, the field has one element, this returns the same output as
+%   [S(:).field]. If fields ar empty or have more than one element, the
+%   output vector will be made to have the same number of elements as S,
+%   and a warning will be thrown. 
+% ● Format
+%   v = pspm_struct2vec(S, field, warningtype)
+% ● Arguments
+%   *           S : a structure array.
+%   *       field : name of a numerical field.
+%   * warningtype : ['marker' or 'generic'] Type of warning to the displayed
+%                   for the user.
+% ● Output
+%   *     v : numerical vector.
+% ● History
+%   Introduced in PsPM 7.0
+%   Written in 2024 Dominik R Bach (Uni Bonn)
+
+if nargin < 3 || strcmpi(warningtype, 'generic')
+    warningstr = 'Element';
+else
+    warningstr = 'Marker value';
+end
+
+% for loops are faster than arrayfun
+n = numel(S);
+v = NaN(n, 1);
+for k = 1:n
+    if numel(S(k).(field)) == 1
+        v(k) = S(k).(field);
+    elseif numel(S(k).(field)) > 1
+        v(k) = S(k).(field)(1);
+        warning('%s #%01.0f contained more than one entry. Only the first one will be retained.\n', warningstr, k);
+    else
+        warning('%s #%01.0f contained no entry and will be assigned NaN.\n', warningstr, k);
+    end
+end
+
+


### PR DESCRIPTION
Fixes #727, an edge case reported in https://github.com/bachlab/PsPM/discussions/719.

Changes proposed in this pull request:
- generalise syntax for `[S(:).field]` for cases in which `numel(S(i).field) ~= 1` in a new function `pspm_struct2vec`
- call this in several import functions
- fix a bug that leads to `markerinfos.values` being char rather than num.
