### PR TITLE
Error correction in `pspm_display`

### DIFF
--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -158,7 +158,7 @@ end
 
 
 % --- Outputs from this function are returned to the command line.
-function handles.output = pspm_display_OutputFcn(~, ~, handles)
+function varargout = pspm_display_OutputFcn(~, ~, handles)
 % varargout  cell array for returning output args (see VARARGOUT);
 % hObject    handle to figure
 % eventdata  reserved - to be defined in a future version of MATLAB


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix an error in `pspm_display.m`
  - `varargout` shall be preserved for outputs in some functions.

Other GUI functions (`pspm_display`, `pspm_data_editor`, `pspm_ecg_editor`) are also checked, and no similar issue has been detected.