### PR TITLE
Fix rev issue

### DIFF
--- a/src/ext/matlabbatch/cfg_util.m
+++ b/src/ext/matlabbatch/cfg_util.m
@@ -994,7 +994,9 @@ switch lower(cmd),
                         cfg_message('matlabbatch:fopen', 'Failed to open ''%s'' for writing:\n%s', jobfile, msg);
                     end
                     fprintf(fid, '%%-----------------------------------------------------------------------\n');
-                    fprintf(fid, '%% Job saved on %s by %s (rev %s)\n', datestr(now), mfilename, rev);
+                    if exist('rev','var')
+                        fprintf(fid, '%% Job saved on %s by %s (rev %s)\n', datestr(now), mfilename, rev);
+                    end
                     versions = cfg_get_defaults('versions');
                     vtags    = fieldnames(versions);
                     for k = 1:numel(vtags)


### PR DESCRIPTION
Fixes the "rev" issue when saving the current job (or job and script).

Changes proposed in this pull request:
- Update cfg_util.m
  - `rev` is no longer used by every function, but it may be available. The saving script would like to add the information, so there is a new checking condition added for the saving operation. The batch script can allow saving the current job without any issue now. 
