### PR TITLE
Sort Format

### DIFF
--- a/src/pspm_bf_FIR.m
+++ b/src/pspm_bf_FIR.m
@@ -4,7 +4,7 @@ function [FIR, x] = pspm_bf_FIR(varargin)
 %   skin conductance responses with n (default 30) post-stimulus timebins of 1
 %   second each.
 % ● Format
-%   [FIR, x] = pspm_bf_FIR(TD, N, D) or
+%   [FIR, x] = pspm_bf_FIR(TD, N, D)
 %   [FIR, x] = pspm_bf_FIR([TD, N, D])
 % ● Arguments
 %   *     TD : sampling interval in seconds.

--- a/src/pspm_bf_hprf_e.m
+++ b/src/pspm_bf_hprf_e.m
@@ -3,7 +3,8 @@ function [bf, x, b] = pspm_bf_hprf_e(varargin)
 %   pspm_bf_hprf_e constructs the heart period response function consisting of
 %   modified Gaussian functions.
 % ● Format
-%   [bf, x, b] = pspm_bf_hprf_e(td, b) or pspm_bf_hprf_e([td, b])
+%   [bf, x, b] = pspm_bf_hprf_e(td, b)
+%   [bf, x, b] = pspm_bf_hprf_e([td, b])
 % ● Arguments
 %   *       td : time resolution in second.
 %   *        b : number of basis functions. Default as 1:6.

--- a/src/pspm_cfg/pspm_cfg_combine_markerchannels.m
+++ b/src/pspm_cfg/pspm_cfg_combine_markerchannels.m
@@ -4,7 +4,7 @@ function combine_markerchannels = pspm_cfg_combine_markerchannels
 %   Matlab UI function for pspm_combine_markerchannels
 % ● History
 %   PsPM 6.2
-%   Written in 2023 by Teddy Chao
+%   Written in 2023 by Teddy
 
 %% Standard items
 datafile         = pspm_cfg_selector_datafile;

--- a/src/pspm_cfg/pspm_cfg_gaze_convert.m
+++ b/src/pspm_cfg/pspm_cfg_gaze_convert.m
@@ -6,7 +6,7 @@ function [pp_gaze_convert] = pspm_cfg_gaze_convert
 % PsPM 3.1
 % (C) 2016 Tobias Moser (University of Zurich)
 % PsPM 5.1.2
-% Updated 2021 Teddy Chao (WCHN, UCL)
+% Updated 2021 Teddy
 
 %% Standard items
 datafile         = pspm_cfg_selector_datafile;

--- a/src/pspm_display.m
+++ b/src/pspm_display.m
@@ -5,8 +5,10 @@ function varargout = pspm_display(varargin)
 %   itself.
 % ● Format
 %   pspm_display
-%   pspm_display(filename), such as pspm_display('test.mat')
-%   pspm_display(filepath), such as pspm_display('~/Documents/test.mat')
+%   pspm_display(filename)
+%   pspm_display('test.mat')
+%   pspm_display(filepath)
+%   pspm_display('~/Documents/test.mat')
 % ● Arguments
 %   * filename: the name of a file to be displayed, which must ends with '.mat'.
 %   * filepath: the path of a file to be displayed, which must ends with '.mat'.

--- a/src/pspm_filtfilt.m
+++ b/src/pspm_filtfilt.m
@@ -2,7 +2,8 @@ function [sts, y] = pspm_filtfilt(b,a,x)
 % ● Description
 %   pspm_filtfilt. Zero-phase forward and reverse digital filtering
 % ● Format
-%   [sts, y] = pspm_filtfilt(b,a,x) or y = pspm_filtfilt(b,a,x)
+%   [sts, y] = pspm_filtfilt(b,a,x)
+%   y = pspm_filtfilt(b,a,x)
 % ● Arguments
 %   * b:  filter parameters (numerator)
 %   * a:  filter parameters (denominator)

--- a/src/pspm_find_valid_fixations.m
+++ b/src/pspm_find_valid_fixations.m
@@ -1,34 +1,33 @@
 function [sts, pos_of_channel, fn] = pspm_find_valid_fixations(fn, varargin)
 % ● Description
 %   pspm_find_valid_fixations finds deviations from a specified gaze
-%   fixation area. The primary usage of this function is to improve 
-%   analyis of pupil size. Pupil size data will be incorrect when gaze is 
-%   not in forward direction, due to foreshortening error. This function 
+%   fixation area. The primary usage of this function is to improve
+%   analyis of pupil size. Pupil size data will be incorrect when gaze is
+%   not in forward direction, due to foreshortening error. This function
 %   allows excluding pupil data points with too large foreshortening. To do
 %   so, it acts on one (or two) pupil channel(s), together with the
-%   associated x/y gaze channels which must have been converted to the 
-%   correct units (distance units, or pixel units for bitmap fixation). 
-%   After finding the invalid fixations from the gaze channels, the 
-%   corresponding data values in the pupil channel are set to NaN. In this 
-%   usage of the function, a circle around fixation point defines the valid 
-%   fixations. Note: an alternative or complement to this strategy is to 
-%   explicitly correct the pupil foreshortening error, see 
+%   associated x/y gaze channels which must have been converted to the
+%   correct units (distance units, or pixel units for bitmap fixation).
+%   After finding the invalid fixations from the gaze channels, the
+%   corresponding data values in the pupil channel are set to NaN. In this
+%   usage of the function, a circle around fixation point defines the valid
+%   fixations. Note: an alternative or complement to this strategy is to
+%   explicitly correct the pupil foreshortening error, see
 %   pspm_pupil_correct and pspm_pupil_correct_eyelink.
 %   An alternative usage of this function is to find fixations on a
 %   particular screen area, e.g. to define overt attention. In this usage,
 %   a bitmap of valid fixation points can be provided, as an alternative to
-%   the circle around fixation point. Since this usage is currently 
-%   considered secondary, it still requires a valid pupil channel as 
+%   the circle around fixation point. Since this usage is currently
+%   considered secondary, it still requires a valid pupil channel as
 %   primary channel, even though unrelated to pupil analysis.
-%   In both usages, valid fixations can be outputted as additional channel. 
-%   By default, screen centre is assumed as fixation point. If an explicit 
-%   fixation point is given, the function assumes that the screen is 
-%   perpendicular to the vector from the eye to the fixation point (which 
-%   is approximately correct for large enough screen distance). 
+%   In both usages, valid fixations can be outputted as additional channel.
+%   By default, screen centre is assumed as fixation point. If an explicit
+%   fixation point is given, the function assumes that the screen is
+%   perpendicular to the vector from the eye to the fixation point (which
+%   is approximately correct for large enough screen distance).
 % ● Format
 %   [sts, channel_index] = pspm_find_valid_fixations(fn, bitmap, options)
-%   [sts, channel_index] = pspm_find_valid_fixations(fn, circle_degree, distance, unit,
-%                                               options)
+%   [sts, channel_index] = pspm_find_valid_fixations(fn, circle_degree, distance, unit, options)
 % ● Arguments
 %   *             fn : The actual data file containing the eyelink recording with gaze
 %                      data converted to cm.
@@ -62,23 +61,23 @@ function [sts, pos_of_channel, fn] = pspm_find_valid_fixations(fn, varargin)
 %   │                 'add'. Possible values are 'add' or 'replace'
 %   ├───.add_invalid: [0/1] If this option is enabled, an extra channel will be
 %   │                 written containing information about the valid samples.
-%   │                 Data points equal to 1 correspond to invalid fixation. 
+%   │                 Data points equal to 1 correspond to invalid fixation.
 %   │                 Default is not to add this channel.
 %   └───────.channel: Choose channels in which the data should be set to NaN
 %                     during invalid fixations. This can be a channel
 %                     number, any channel type including 'pupil' (which
 %                     will select a channel according to the precedence
 %                     order specified in pspm_load_channel), or 'both',
-%                     which will work on 'pupil_r' and 'pupil_l' and 
-%                     then update channel statistics and best eye. 
-%                     The selected channel must be an eyetracker 
-%                     channel, and the file must contain the corresponding 
+%                     which will work on 'pupil_r' and 'pupil_l' and
+%                     then update channel statistics and best eye.
+%                     The selected channel must be an eyetracker
+%                     channel, and the file must contain the corresponding
 %                     gaze channel(s) in the correct units: distance units for
-%                     mode "fixation" and distance or pixel units for mode 
+%                     mode "fixation" and distance or pixel units for mode
 %                     "bitmap".
-%                     Default is 'pupil'. 
+%                     Default is 'pupil'.
 % ● References
-%   [1]  Korn CW & Bach DR (2016). A solid frame for the window on cognition: 
+%   [1]  Korn CW & Bach DR (2016). A solid frame for the window on cognition:
 %        Modelling event-related pupil responses. Journal of Vision, 16:28,1-6.
 % ● Developer note
 %   Additional i/o options for recursive calls are not included in the help.

--- a/src/pspm_gaze_pp.m
+++ b/src/pspm_gaze_pp.m
@@ -1,10 +1,10 @@
 function [sts, channel_index] = pspm_gaze_pp(fn, options)
 % ● Description
 %   pspm_gaze_pp combines left/right gaze x and gaze y channels at
-%   the same time and will add two combined gaze channels, for the x and y 
+%   the same time and will add two combined gaze channels, for the x and y
 %   coordinate.
 % ● Format
-%   [sts, channel_index] = pspm_gaze_pp(fn) or
+%   [sts, channel_index] = pspm_gaze_pp(fn)
 %   [sts, channel_index] = pspm_gaze_pp(fn, options)
 % ● Arguments
 %   *             fn: [string] Path to the PsPM file which contains the gaze data.

--- a/src/pspm_get_cnt.m
+++ b/src/pspm_get_cnt.m
@@ -3,6 +3,7 @@ function [sts, import, sourceinfo] = pspm_get_cnt(datafile, import)
 %   pspm_get_cnt imports NeuroScan cnt files using FieldTrip functions.
 % ● Format
 %   [sts, import, sourceinfo] = pspm_get_cnt(datafile, import);
+% ● Developer's notes
 %   This function uses fieldtrip fileio functions
 % ● Arguments
 %   *   datafile : The data file to be imported.

--- a/src/pspm_jobman.m
+++ b/src/pspm_jobman.m
@@ -3,18 +3,16 @@ function job_id = pspm_jobman(varargin)
 %   Main interface for PsPM Batch System
 %   Initialise jobs configuration and set MATLAB path accordingly.
 % ● Format
-%     pspm_jobman('initcfg')
-%   → Run specified job
-%     pspm_jobman('run',job)
-%     output_list = pspm_jobman('run',job)
-%   → Run specified job
-%     job_id = pspm_jobman
-%     job_id = pspm_jobman('interactive')
-%     job_id = pspm_jobman('interactive',job)
-%     job_id = pspm_jobman('interactive',job,node)
-%     job_id = pspm_jobman('interactive','',node)
+%   pspm_jobman('initcfg')
+%   pspm_jobman('run',job) // Run specified job
+%   output_list = pspm_jobman('run',job)
+%   job_id = pspm_jobman // Run specified job
+%   job_id = pspm_jobman('interactive')
+%   job_id = pspm_jobman('interactive',job)
+%   job_id = pspm_jobman('interactive',job,node)
+%   job_id = pspm_jobman('interactive','',node)
 % ● Arguments
-%   → Run specified job
+%   // Run specified job
 %   *         job:  filename of a job (.m or .mat), or cell
 %                   array of filenames, or 'jobs'/'matlabbatch'
 %                   variable, or cell array of 'jobs'/'matlabbatch'
@@ -23,7 +21,7 @@ function job_id = pspm_jobman(varargin)
 %                   each module in the job. The format and contents
 %                   of these outputs is defined in the configuration
 %                   of each module (.prog and .vout callbacks).
-%   → Run the user interface in interactive mode.
+%   // Run the user interface in interactive mode.
 %   *        node:  indicate which part of the configuration is to be used.
 %   *      job_id:  can be used to manipulate this job in cfg_util. Note that
 %                   changes to the job in cfg_util will not show up in cfg_ui

--- a/src/pspm_load_channel.m
+++ b/src/pspm_load_channel.m
@@ -4,8 +4,7 @@ function [sts, data_struct, infos, pos_of_channel, chantype_sts] = ...
 %   pspm_load_channel loads a single data channel and provides integrated
 %   channel checking logic
 % ● Format
-%   [sts, data_struct, infos, pos_of_channel, chantype_correct] = 
-%                               pspm_load_channel(fn, channel, channeltype)
+%   [sts, data_struct, infos, pos_of_channel, chantype_correct] = pspm_load_channel(fn, channel, channeltype)
 % ● Arguments
 %   *      fn : the filename, can be either a string or a struct (as below).
 %   ┌──────fn
@@ -33,11 +32,11 @@ function [sts, data_struct, infos, pos_of_channel, chantype_sts] = ...
 %                 (1) .channel: as defined for the 'char' option above;
 %                 (2) .units: units of the channel.
 %   * channeltype: [char] optional; any channel type as permitted per pspm_init,
-%                 'wave', or 'events': checks whether retrieved data channel 
+%                 'wave', or 'events': checks whether retrieved data channel
 %                is of the specified type and gives a warning if not
 % ● Outputs
 %   *            sts : [logical] 1 as default, -1 if unsuccessful.
-%   *    data_struct : a struct with fields .data and .header, corresponding to a single 
+%   *    data_struct : a struct with fields .data and .header, corresponding to a single
 %                      cell of a data cell array returned by pspm_load_data.
 %   *          infos : file infos as returned from pspm_load_data.
 %   * pos_of_channel : index of the returned channel.
@@ -143,7 +142,7 @@ else
 end
 
 % if channeltype is given, check if channel is of correct type
-if nargin > 2 
+if nargin > 2
     warning('off', 'all');
     chantype_sts = pspm_select_channels({data_struct}, channeltype);
     warning('on', 'all');


### PR DESCRIPTION
This PR sort the *Format* section in help text.

`pspm_doc` can read the help text and sort them by adding `or` between multiple possible formats.

Changes proposed in this pull request:
- update a few formats.