### PR TITLE
fix illuminance GUI

### DIFF
--- a/src/pspm_bf_lcrf_gm.m
+++ b/src/pspm_bf_lcrf_gm.m
@@ -10,8 +10,7 @@ function [bs, x] = pspm_bf_lcrf_gm(varargin)
 % ● Arguments
 %   *    td : time resolution in second.
 %   *     n : duration of the function in s. Default as 20 s.
-%   * offset: offset in s. tells the function where to start with
-%             the response function. Default as 0.2 s.
+%   * offset: offset of the response function (in s).
 %   *     a : shape of the function.
 %   *     b : scale of the function.
 %   *     A : quantifier or amplitude of the function

--- a/src/pspm_bf_ldrf_gm.m
+++ b/src/pspm_bf_ldrf_gm.m
@@ -10,8 +10,7 @@ function [bs, x] = pspm_bf_ldrf_gm(varargin)
 % ● Arguments
 %   *     td : Time resolution in second.
 %   *      n : Duration of the function in second. Default as 20 s.
-%   * offset : Offset in s. tells the function where to start with
-%              the response function. Default as 0.2 s.
+%   * offset : Offset of the response (in s).
 %   *      a : Shape of the function.
 %   *      b : Scale of the function.
 %   *      A : Quantifier or amplitude of the function.

--- a/src/pspm_cfg/pspm_cfg_process_illuminance.m
+++ b/src/pspm_cfg/pspm_cfg_process_illuminance.m
@@ -26,22 +26,6 @@ sr.tag          = 'sr';
 sr.strtype      = 'i';
 sr.num          = [1 1];
 sr.help         = pspm_cfg_help_format('pspm_process_illuminance', 'sr');
-%% Duration
-duration        = cfg_entry;
-duration.name   = 'Duration';
-duration.tag    = 'duration';
-duration.strtype= 'r';
-duration.val    = {20};
-duration.num    = [1 1];
-duration.help   = pspm_cfg_help_format('pspm_process_illuminance', 'options.bf.duration');
-%% Offset
-offset          = cfg_entry;
-offset.name     = 'Offset';
-offset.tag      = 'offset';
-offset.strtype  = 'r';
-offset.val      = {0.2};
-offset.num      = [1 1];
-offset.help     = pspm_cfg_help_format('pspm_process_illuminance', 'options.bf.offset');
 %% LDRF_GM
 ldrf_gm         = cfg_const;
 ldrf_gm.name    = 'pspm_bf_ldrf_gm';
@@ -78,7 +62,7 @@ constrict.help  = pspm_cfg_help_format('pspm_process_illuminance', 'options.bf.c
 bf              = cfg_branch;
 bf.name         = 'Basis function options';
 bf.tag          = 'bf';
-bf.val          = {duration, offset, dilation, constrict};
+bf.val          = {dilation, constrict};
 bf.help         = {'Specify options for the basis functions.'};
 
 %% Executable branch

--- a/src/pspm_cfg/pspm_cfg_run_proc_illuminance.m
+++ b/src/pspm_cfg/pspm_cfg_run_proc_illuminance.m
@@ -8,7 +8,6 @@ options.fn = out_file;
 options.overwrite = job.output.overwrite;
 %% basis function
 options.bf = struct();
-options.bf = pspm_update_struct(options.bf, job.bf, {'duration','offset'});
 dil_f = fields(job.bf.dilation);
 % only check first field
 switch dil_f{1}


### PR DESCRIPTION
Changes proposed in this pull request:
- removes the response function options "duration" and "offset" from the illuminance GLM. There is no point changing these two if the other parameters cannot be changed. 