### PR TITLE
fix SF issue with timeunits == 'whole'

### DIFF
--- a/src/pspm_check_model.m
+++ b/src/pspm_check_model.m
@@ -168,7 +168,7 @@ end
 if ~isfield(model, 'timing')
     model.timing = cell(nFile, 1);
 elseif ~iscell(model.timing) || ...
-  (strcmpi(modeltype, 'dcm') && ~iscell(model.timing{1}) && ~ischar(model.timing{1}))
+  (strcmpi(modeltype, 'dcm') && ~isempty(model.timing) && ~iscell(model.timing{1})  && ~ischar(model.timing{1}))
   % for DCM, model.timing is either a file name or a cell array of
   % events, or a cell array of file names or cell arrays, so we need to
   % take care of cases where model.timing is a cell array but not a cell

--- a/src/pspm_check_model.m
+++ b/src/pspm_check_model.m
@@ -196,7 +196,8 @@ elseif ~any(ismember(model.norm, [0, 1]))
 end
 
 %% 4. Check that session-related field entries have compatible size
-if (nFile ~= numel(model.timing)) && ~(numel(model.timing) == 0 && isfield(model, 'nuisance'))
+if (nFile ~= numel(model.timing)) && ...
+    ~(numel(model.timing) == 0 && (isfield(model, 'nuisance') || (isfield(model, 'timeunits') && strcmpi(model.timeunits, 'whole'))))
   warning('ID:number_of_elements_dont_match',...
     'Session numbers of data files and event definitions do not match.');
   return

--- a/src/pspm_check_model.m
+++ b/src/pspm_check_model.m
@@ -131,16 +131,18 @@ if isempty(settings)
   pspm_init;
 end
 
-options = pspm_options(options, modeltype);
-if options.invalid
-    return
-end
-
 %% 1. General checks  ------------------------------------------------------
 if ~isstruct(model) || isempty(model)
   warning('ID:invalid_input', 'Model must be a non-empty struct.');
   model = struct('invalid', 1);
   return
+else
+    model.invalid = 1;
+end
+
+options = pspm_options(options, modeltype);
+if options.invalid
+    return
 end
 
 %% 2. Reject missing mandatory fields common to all models -----------------

--- a/src/pspm_check_model.m
+++ b/src/pspm_check_model.m
@@ -167,17 +167,13 @@ end
 %% 3. Fill missing fields common to all models, and accept only allowed values
 if ~isfield(model, 'timing')
     model.timing = cell(nFile, 1);
-else
-  if ~isempty(model.timing)
-    if ~iscell(model.timing) || ...
-      (strcmpi(modeltype, 'dcm') && ~iscell(model.timing{1}) && ~ischar(model.timing{1}))
-      % for DCM, model.timing is either a file name or a cell array of
-      % events, or a cell array of file names or cell arrays, so we need to
-      % take care of cases where model.timing is a cell array but not a cell
-      % array of cell arrays or a cell array of char
-      model.timing = {model.timing};
-    end
-  end
+elseif ~iscell(model.timing) || ...
+  (strcmpi(modeltype, 'dcm') && ~iscell(model.timing{1}) && ~ischar(model.timing{1}))
+  % for DCM, model.timing is either a file name or a cell array of
+  % events, or a cell array of file names or cell arrays, so we need to
+  % take care of cases where model.timing is a cell array but not a cell
+  % array of cell arrays or a cell array of char
+  model.timing = {model.timing};
 end
 if ~isfield(model, 'missing')
   model.missing = cell(nFile, 1);

--- a/src/pspm_dcm.m
+++ b/src/pspm_dcm.m
@@ -203,16 +203,10 @@ warnings = {};
 if nargin < 1; errmsg = 'Nothing to do.'; warning('ID:invalid_input', errmsg); return
 elseif nargin < 2; options = struct(); end
 
-% 2.2 check model
-model = pspm_check_model(model, 'dcm');
-if model.invalid
+% 2.2 check model and options
+[model, options] = pspm_check_model(model, options, 'dcm');
+if model.invalid || options.invalid
     return
-end
-
-% 2.3 check options
-options = pspm_options(options, 'dcm');
-if options.invalid
-  return
 end
 
 % all the below should be re-factored into pspm_options -------------------

--- a/src/pspm_extract_segments.m
+++ b/src/pspm_extract_segments.m
@@ -104,7 +104,8 @@ if strcmpi(method, 'file') % in this case use pspm_check_model to verify
     if isfield(options, 'missing')
         model.missing = options.missing;
     end
-    model = pspm_check_model(model, 'glm');
+    % set overwrite = 1 to override test of existing model file
+    model = pspm_check_model(model, struct('overwrite', 1), 'glm'); 
     if model.invalid, return; end
     timing = model.timing;
     datafile = model.datafile;

--- a/src/pspm_glm.m
+++ b/src/pspm_glm.m
@@ -205,24 +205,10 @@ tmp = struct([]); % temporary model structure
 if nargin < 1; errmsg = 'Nothing to do.'; warning('ID:invalid_input', errmsg); return
 elseif nargin < 2; options = struct(); end
 
-% 2.2 check model
-model = pspm_check_model(model, 'glm');
-if model.invalid
+% 2.2 check model and options
+[model, options] = pspm_check_model(model, options, 'glm');
+if model.invalid || options.invalid
     return
-end
-
-% 2.3 check options
-options = pspm_options(options, 'glm');
-if options.invalid
-  return
-end
-
-% 2.4 check files
-% stop the script if files are not allowed to overwrite
-options.overwrite = pspm_overwrite(model.modelfile, options);
-if ~options.overwrite
-  warning('ID:invalid_input', 'Model file exists, and overwriting not allowed by user.');
-  return
 end
 
 %% 3 Check & get data

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -1,31 +1,31 @@
 function [sts, sf] = pspm_sf(model, options)
 % ● Description
 %   pspm_sf is a wrapper function for analysis of skin conductance as a
-%   measure of tonic arousal. SF are analysed over time windows that 
-%   typically last 60 s and should at least be 15 s long. PsPM implements 3 
-%   different models. 
+%   measure of tonic arousal. SF are analysed over time windows that
+%   typically last 60 s and should at least be 15 s long. PsPM implements 3
+%   different models.
 %   (1) Skin conductance level (SCL): this is the mean signal over the
 %   epoch.
 %   (2) Area under the curve (AUC): this is the time-integral of the signal
 %   with the minimum value subtracted (to account for pre-epoch arousal),
-%   divided by epoch duration. This is designed to be independent from SCL 
-%   and ideally represents the number x amplitude of spontaneous 
-%   fluctuations (also termed non-specific SCR) in this epoch. 
-%   (3) Number of SF estimated by DCM: this is a non-linear estimation of 
-%   the number and onset of SF, and is the most sensitive indicator of 
+%   divided by epoch duration. This is designed to be independent from SCL
+%   and ideally represents the number x amplitude of spontaneous
+%   fluctuations (also termed non-specific SCR) in this epoch.
+%   (3) Number of SF estimated by DCM: this is a non-linear estimation of
+%   the number and onset of SF, and is the most sensitive indicator of
 %   tonic arousal. For counting peaks, a threshold in mcS is applied; hence
-%   it is important that the data are provided in the correct units. Estimated 
-%   SF onset is stored in the model and is expressed in CNS time, i.e. the 
-%   time point at which an SF was generated in the CNS. Thus, it already 
+%   it is important that the data are provided in the correct units. Estimated
+%   SF onset is stored in the model and is expressed in CNS time, i.e. the
+%   time point at which an SF was generated in the CNS. Thus, it already
 %   takes into account the conduction delay from CNS into the periphery.
 %   (4) Number of SF estimated by MP: This is the same model as in (3) but
-%   estimated with an approximative matching pursuit (MP) algorithm. 
+%   estimated with an approximative matching pursuit (MP) algorithm.
 % ● Format
 %   [sts, sf] = pspm_sf(model, options)
 % ● Arguments
 %   ┌──────────model
-%   ├──────.datafile :  one data filename or cell array of filenames.
-%   ├─────.modelfile :  one data filename or cell array of filenames.
+%   ├──────.datafile :  one data filename
+%   ├─────.modelfile :  one model filename
 %   ├────────.timing :  can be one of the following
 %   │                   - an SPM style onset file with two event types: onset &
 %   │                     offset (names are ignored)
@@ -40,10 +40,9 @@ function [sts, sf] = pspm_sf(model, options)
 %   │                   [string] accept 'auc', 'scl', 'dcm', or 'mp', default as 'dcm'.
 %   │                   [cell_array] a cell array of methods mentioned above.
 %   ├────────.filter :  [optional] filter settings; modality specific default
-%   ├───────.missing :  [optional, string/cell_array] [default: no missing values]
+%   ├───────.missing :  [optional, string] [default: no missing values]
 %   │                   Allows to specify missing (e.g. artefact) epochs in the data file.
-%   │                   See pspm_get_timing for epoch definition; specify a cell array
-%   │                   for multiple input files. This must always be specified in SECONDS.
+%   │                   See pspm_get_timing for epoch definition. This must always be specified in SECONDS.
 %   └───────.channel :  [optional, integer, default: last SCR channel] Channel number.
 %   ┌────────options
 %   ├─────.overwrite :  [logical, default: determined by pspm_overwrite]
@@ -59,7 +58,7 @@ function [sts, sf] = pspm_sf(model, options)
 %   │                   (Maximum) frequency (in Hz) of responses in the model.
 %   │                   (Used for DCM and MP only.)
 %   ├───────.dispwin :  [logical, default: 1]
-%   │                   Display progress plot (DCM) or result plot (MP). 
+%   │                   Display progress plot (DCM) or result plot (MP).
 %   ├──.dispsmallwin :  [logical, default: 0]
 %   │                   Display intermediate progress windows. (Used for DCM only.)
 %   └─.missingthresh :  [numeric, default: 2] [unit: second]
@@ -91,7 +90,7 @@ function [sts, sf] = pspm_sf(model, options)
 %% 1 Initialise
 global settings
 if isempty(settings)
-  pspm_init;
+    pspm_init;
 end
 outfile = [];
 sts = -1;
@@ -108,164 +107,161 @@ if model.invalid || options.invalid
     return
 end
 
+model.timing = model.timing{1};
+model.datafile = model.datafile{1};
+model.missing = model.missing{1};
+
 %% 3. Parse methods
 method = cell(numel(model.method), 1);
 fhandle = method;
 datatype = NaN(numel(model.method));
 for k = 1:numel(model.method)
-switch model.method{k}
-  case {'auc', 'AUC'}
-    method{k} = 'auc';
-    fhandle{k} = @pspm_sf_auc;
-    datatype(k) = 2; % filtered
-  case {'DCM', 'dcm'}
-    method{k} = 'dcm';
-    fhandle{k} = @pspm_sf_dcm;
-    datatype(k) = 2; % filtered
-  case {'MP', 'mp'}
-    method{k} = 'mp';
-    fhandle{k} = @pspm_sf_mp;
-    datatype(k) = 2; % filtered
-  case {'SCL', 'scl', 'level'}
-    method{k} = 'scl';
-    fhandle{k} = @pspm_sf_scl;
-    datatype(k) = 1; % unfiltered
-  case 'all'
-    method = {'scl', 'auc', 'dcm', 'mp'};
-    fhandle = {@pspm_sf_scl, @pspm_sf_auc,  @pspm_sf_dcm, @pspm_sf_mp};
-    datatype = [1 2 2 2];
-  otherwise
-    warning('Method %s not supported', model.method{k}); return;
-end
+    switch model.method{k}
+        case {'auc', 'AUC'}
+            method{k} = 'auc';
+            fhandle{k} = @pspm_sf_auc;
+            datatype(k) = 2; % filtered
+        case {'DCM', 'dcm'}
+            method{k} = 'dcm';
+            fhandle{k} = @pspm_sf_dcm;
+            datatype(k) = 2; % filtered
+        case {'MP', 'mp'}
+            method{k} = 'mp';
+            fhandle{k} = @pspm_sf_mp;
+            datatype(k) = 2; % filtered
+        case {'SCL', 'scl', 'level'}
+            method{k} = 'scl';
+            fhandle{k} = @pspm_sf_scl;
+            datatype(k) = 1; % unfiltered
+        case 'all'
+            method = {'scl', 'auc', 'dcm', 'mp'};
+            fhandle = {@pspm_sf_scl, @pspm_sf_auc,  @pspm_sf_dcm, @pspm_sf_mp};
+            datatype = [1 2 2 2];
+        otherwise
+            warning('Method %s not supported', model.method{k}); return;
+    end
 
 end
 % 2.6 Get timing --
 if strcmpi(model.timeunits, 'whole')
-  epochs = repmat({[1 1]}, numel(model.datafile), 1);
+    epochs = repmat({[1 1]}, numel(model.datafile), 1);
 else
-  for iFile = 1:numel(model.datafile)
-    [sts, epochs{iFile}] = pspm_get_timing('epochs', model.timing{iFile}, model.timeunits);
-  end
+    for iFile = 1:numel(model.datafile)
+        [sts, epochs{iFile}] = pspm_get_timing('epochs', model.timing, model.timeunits);
+    end
 end
 
-options = pspm_options(options, 'sf');
-if options.invalid
-  return
-end
 
 %% 3 Get data
-nFile = numel(model.datafile);
-for iFile = 1:nFile
-  % 3.1 User output
-  fprintf('SF analysis: %s ...', model.datafile{iFile});
+% 3.1 User output
+fprintf('SF analysis: %s ...', model.datafile);
 
-  % 3.2 get and filter data --
-  [sts_load_data, data] = pspm_load_channel(model.datafile{iFile}, model.channel, 'scr');
-  if sts_load_data < 0, return; end
-  y{1} = data.data;
-  sr(1) = data.header.sr;
-  model.filter.sr = sr(1);
-  [sts_prepdata, y{2}, sr(2)] = pspm_prepdata(y{1}, model.filter);
-  % always use last data channels
-  if sts_prepdata == -1
+% 3.2 get and filter data --
+[sts_load_data, data] = pspm_load_channel(model.datafile, model.channel, 'scr');
+if sts_load_data < 0, return; end
+y{1} = data.data;
+sr(1) = data.header.sr;
+model.filter.sr = sr(1);
+[sts_prepdata, y{2}, sr(2)] = pspm_prepdata(y{1}, model.filter);
+% always use last data channels
+if sts_prepdata == -1
     warning('ID:invalid_input', 'Call of pspm_prepdata failed.');
     return;
-  end
-  % 3.3 Check data units
-  if ~strcmpi(data.header.units, 'uS') && any(strcmpi('dcm', method))
+end
+% 3.3 Check data units
+if ~strcmpi(data.header.units, 'uS') && any(strcmpi('dcm', method))
     fprintf(['\nYour data units are stored as %s, ',...
-      'and the method will apply an amplitude threshold in uS. ',...
-      'Please check your results.\n'], ...
-      data.header.units);
-  end
-  % 3.4 Get missing epochs --
-  if ~isempty(model.missing{iFile})
+        'and the method will apply an amplitude threshold in uS. ',...
+        'Please check your results.\n'], ...
+        data.header.units);
+end
+% 3.4 Get missing epochs --
+if ~isempty(model.missing)
     [~, missing{iFile}] = pspm_get_timing('missing', model.missing{iFile}, 'seconds');
     model.missing_data = zeros(size(y{2}));
-    missing_index = pspm_time2index(missing{iFile}, sr(datatype(k)));
+    missing_index = pspm_time2index(missing, sr(datatype(k)));
     model.missing_data((missing_index(:,1)+1):(missing_index(:,2)+1)) = 1;
-  else
-    missing{iFile} = [];
-  end
-  % 3.5 Get marker data --
-  if any(strcmp(model.timeunits, {'marker', 'markers'}))
-    [sts, ndata] = pspm_load_channel(model.datafile{iFile}, options.marker_chan_num, 'marker');
+else
+    missing= [];
+end
+% 3.5 Get marker data --
+if any(strcmp(model.timeunits, {'marker', 'markers'}))
+    [sts, ndata] = pspm_load_channel(model.datafile, options.marker_chan_num, 'marker');
     if sts < 1, return;  end
     events{iFile} = ndata.data(:);
-  end
+end
 
-  for iEpoch = 1:size(epochs{iFile}, 1)
+for iEpoch = 1:size(epochs{iFile}, 1)
     if iEpoch > 1, fprintf('\n\t\t\t'); end
     fprintf('epoch %01.0f ...', iEpoch);
     for k = 1:numel(method)
-      fprintf('%s ', method{k});
-      switch model.timeunits
-        case 'seconds'
-          win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)));
-        case 'samples'
-          win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)) / sr(1));
-        case 'markers'
-          win = round(events{iFile}(epochs{iFile}(iEpoch, :)) * sr(datatype(k)));
-        case 'whole'
-          win = [1 numel(y{datatype(k)})];
-      end
-      if any(win > numel(y{datatype(k)}) + 1) || any(win < 0)
-        warning('\nEpoch %2.0f outside of file %s ...', iEpoch, model.modelfile{iFile});
-        inv_flag = 0;
-      else
-        inv_flag = 1;
-        % correct issues with using 'round'
-        win(1) = max(win(1), 1);
-        win(2) = min(win(2), numel(y{datatype(k)}));
-      end
-      if diff(win) < 4
-          warning('\nEpoch %2.0f contains insufficient data ...', iEpoch);
-          inv_flag = 0;
-      end
-      % 3.6.1 collect information --
-      sf.model{k}(iEpoch).modeltype = method{k};
-      sf.model{k}(iEpoch).boundaries = squeeze(epochs{iFile}(iEpoch, :));
-      sf.model{k}(iEpoch).timeunits  = model.timeunits;
-      sf.model{k}(iEpoch).samples    = win;
-      sf.model{k}(iEpoch).sr         = sr(datatype(k));
-      %
-      escr = y{datatype(k)}(win(1):win(end));
-      sf.model{k}(iEpoch).data = escr;
+        fprintf('%s ', method{k});
+        switch model.timeunits
+            case 'seconds'
+                win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)));
+            case 'samples'
+                win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)) / sr(1));
+            case 'markers'
+                win = round(events{iFile}(epochs{iFile}(iEpoch, :)) * sr(datatype(k)));
+            case 'whole'
+                win = [1 numel(y{datatype(k)})];
+        end
+        if any(win > numel(y{datatype(k)}) + 1) || any(win < 0)
+            warning('\nEpoch %2.0f outside of file %s ...', iEpoch, model.datafile);
+            inv_flag = 0;
+        else
+            inv_flag = 1;
+            % correct issues with using 'round'
+            win(1) = max(win(1), 1);
+            win(2) = min(win(2), numel(y{datatype(k)}));
+        end
+        if diff(win) < 4
+            warning('\nEpoch %2.0f contains insufficient data ...', iEpoch);
+            inv_flag = 0;
+        end
+        % 3.6.1 collect information --
+        sf.model{k}(iEpoch).modeltype = method{k};
+        sf.model{k}(iEpoch).boundaries = squeeze(epochs{iFile}(iEpoch, :));
+        sf.model{k}(iEpoch).timeunits  = model.timeunits;
+        sf.model{k}(iEpoch).samples    = win;
+        sf.model{k}(iEpoch).sr         = sr(datatype(k));
+        %
+        escr = y{datatype(k)}(win(1):win(end));
+        sf.model{k}(iEpoch).data = escr;
 
-      % 3.6.2 do the analysis and collect results --
-      if ~isempty(model.missing{iFile})
-        model_analysis = struct('scr', escr, 'sr', sr(datatype(k)), 'missing_data', model.missing_data(win(1):win(end)));
-      else
-        model_analysis = struct('scr', escr, 'sr', sr(datatype(k)));
-      end
-      if inv_flag ~= 0
-        [sts, invrs] = fhandle{k}(model_analysis, options);
-        sf.model{k}(iEpoch).inv = invrs;
-      else
-        sf.model{k}(iEpoch).inv = [];
-      end
-      if inv_flag == 0
-        sf.stats(iEpoch, k) = NaN;
-      elseif any(strcmpi(method{k}, {'dcm', 'mp'}))
-        sf.stats(iEpoch, k)         = invrs.f;
-      else
-        sf.stats(iEpoch, k)         = invrs;
-      end
+        % 3.6.2 do the analysis and collect results --
+        if ~isempty(model.missing)
+            model_analysis = struct('scr', escr, 'sr', sr(datatype(k)), 'missing_data', model.missing_data(win(1):win(end)));
+        else
+            model_analysis = struct('scr', escr, 'sr', sr(datatype(k)));
+        end
+        if inv_flag ~= 0
+            [sts, invrs] = fhandle{k}(model_analysis, options);
+            sf.model{k}(iEpoch).inv = invrs;
+        else
+            sf.model{k}(iEpoch).inv = [];
+        end
+        if inv_flag == 0
+            sf.stats(iEpoch, k) = NaN;
+        elseif any(strcmpi(method{k}, {'dcm', 'mp'}))
+            sf.stats(iEpoch, k)         = invrs.f;
+        else
+            sf.stats(iEpoch, k)         = invrs;
+        end
     end
     sf.trlnames{iEpoch} = sprintf('Epoch #%d', iEpoch);
-  end
-  sf.names = method(:);
-  sf.infos.date = date;
-  sf.infos.file = model.modelfile{iFile};
-  sf.modelfile = model.modelfile{iFile};
-  sf.data = y;
-  if exist('events','var'), sf.events = events; end
-  sf.input = model;
-  sf.options = options;
-  sf.modeltype = 'sf';
-  sf.modality = settings.modalities.sf;
-  save(model.modelfile{iFile}, 'sf');
-  fprintf('\n');
 end
+sf.names = method(:);
+sf.infos.date = date;
+sf.infos.file = model.modelfile;
+sf.modelfile = model.modelfile;
+sf.data = y;
+if exist('events','var'), sf.events = events; end
+sf.input = model;
+sf.options = options;
+sf.modeltype = 'sf';
+sf.modality = settings.modalities.sf;
+save(model.modelfile, 'sf');
+fprintf('\n');
 sts = 1;
 

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -102,29 +102,10 @@ sts = -1;
 if nargin < 1; errmsg = 'Nothing to do.'; warning('ID:invalid_input', errmsg); return
 elseif nargin < 2; options = struct(); end
 
-% 2.2 check model
-model = pspm_check_model(model, 'sf');
-if model.invalid
+% 2.2 check model and options
+[model, options] = pspm_check_model(model, options, 'sf');
+if model.invalid || options.invalid
     return
-end
-
-% 2.3 check options
-options = pspm_options(options, 'sf');
-if options.invalid
-  return
-end
-
-[~, ~, ext] = fileparts(model.modelfile);
-if isempty(ext{1})
-    modelfile_temp = strcat(model.modelfile,'.mat');
-else
-    modelfile_temp = model.modelfile;
-end
-
-% 2.4 check files
-% stop the script if files are not allowed to overwrite
-if ~pspm_overwrite(modelfile_temp, options)
-  return
 end
 
 %% 3. Parse methods

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -114,9 +114,16 @@ if options.invalid
   return
 end
 
+[~, ~, ext] = fileparts(model.modelfile);
+if isempty(ext{1})
+    modelfile_temp = strcat(model.modelfile,'.mat');
+else
+    modelfile_temp = model.modelfile;
+end
+
 % 2.4 check files
 % stop the script if files are not allowed to overwrite
-if ~pspm_overwrite(model.modelfile, options)
+if ~pspm_overwrite(modelfile_temp, options)
   return
 end
 

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -147,7 +147,7 @@ end
 if strcmpi(model.timeunits, 'whole')
     epochs = [1 1];
 else
-    epochs = pspm_get_timing('epochs', model.timing, model.timeunits);
+    [sts, epochs] = pspm_get_timing('epochs', model.timing, model.timeunits);
 end
 
 

--- a/src/pspm_sf.m
+++ b/src/pspm_sf.m
@@ -142,13 +142,12 @@ for k = 1:numel(model.method)
     end
 
 end
+
 % 2.6 Get timing --
 if strcmpi(model.timeunits, 'whole')
-    epochs = repmat({[1 1]}, numel(model.datafile), 1);
+    epochs = [1 1];
 else
-    for iFile = 1:numel(model.datafile)
-        [sts, epochs{iFile}] = pspm_get_timing('epochs', model.timing, model.timeunits);
-    end
+    epochs = pspm_get_timing('epochs', model.timing, model.timeunits);
 end
 
 
@@ -177,7 +176,7 @@ if ~strcmpi(data.header.units, 'uS') && any(strcmpi('dcm', method))
 end
 % 3.4 Get missing epochs --
 if ~isempty(model.missing)
-    [~, missing{iFile}] = pspm_get_timing('missing', model.missing{iFile}, 'seconds');
+    [~, missing{iFile}] = pspm_get_timing('missing', model.missing, 'seconds');
     model.missing_data = zeros(size(y{2}));
     missing_index = pspm_time2index(missing, sr(datatype(k)));
     model.missing_data((missing_index(:,1)+1):(missing_index(:,2)+1)) = 1;
@@ -191,18 +190,18 @@ if any(strcmp(model.timeunits, {'marker', 'markers'}))
     events{iFile} = ndata.data(:);
 end
 
-for iEpoch = 1:size(epochs{iFile}, 1)
+for iEpoch = 1:size(epochs, 1)
     if iEpoch > 1, fprintf('\n\t\t\t'); end
     fprintf('epoch %01.0f ...', iEpoch);
     for k = 1:numel(method)
         fprintf('%s ', method{k});
         switch model.timeunits
             case 'seconds'
-                win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)));
+                win = round(epochs(iEpoch, :) * sr(datatype(k)));
             case 'samples'
-                win = round(epochs{iFile}(iEpoch, :) * sr(datatype(k)) / sr(1));
+                win = round(epochs(iEpoch, :) * sr(datatype(k)) / sr(1));
             case 'markers'
-                win = round(events{iFile}(epochs{iFile}(iEpoch, :)) * sr(datatype(k)));
+                win = round(events{iFile}(epochs(iEpoch, :)) * sr(datatype(k)));
             case 'whole'
                 win = [1 numel(y{datatype(k)})];
         end
@@ -221,7 +220,7 @@ for iEpoch = 1:size(epochs{iFile}, 1)
         end
         % 3.6.1 collect information --
         sf.model{k}(iEpoch).modeltype = method{k};
-        sf.model{k}(iEpoch).boundaries = squeeze(epochs{iFile}(iEpoch, :));
+        sf.model{k}(iEpoch).boundaries = squeeze(epochs(iEpoch, :));
         sf.model{k}(iEpoch).timeunits  = model.timeunits;
         sf.model{k}(iEpoch).samples    = win;
         sf.model{k}(iEpoch).sr         = sr(datatype(k));

--- a/src/pspm_sf_auc.m
+++ b/src/pspm_sf_auc.m
@@ -4,9 +4,14 @@ function [sts, auc] = pspm_sf_auc(model, options)
 % ● Format
 %   [sts, auc] = pspm_sf_auc(scr, sr, options)
 % ● Arguments
-%   *     scr : the SCR time series
-%   *      sr : sampling rate.
-%   * options : the options struct.
+%   ┌────────model
+%   ├─────────.scr : skin conductance epoch (maximum size depends on computing power,
+%   │                a sensible size is 60 s at 10 Hz)
+%   ├──────────.sr : [numeric] [unit: Hz] sampling rate.
+%   └.missing_data : [Optional] missing epoch data, originally loaded as model.missing
+%                    from pspm_sf, but calculated into .missing_data (created
+%                    in pspm_sf and then transferred to pspm_sf_dcm.
+%   * options: the options struct (not used)
 % ● Outputs
 %   *     auc : The calculated area under the curve.
 % ● Reference
@@ -35,9 +40,7 @@ if nargin < 1
   warning('No data specified'); return;
 end;
 try model.scr; catch, warning('Input data is not defined.'); return; end
-try model.sr; catch, warning('Sample rate is not defined.'); return; end
 scr = model.scr;
-sr = model.sr;
 scr = scr - min(scr);
 auc = mean(scr);
 sts = 1;

--- a/src/pspm_sf_scl.m
+++ b/src/pspm_sf_scl.m
@@ -4,9 +4,14 @@ function [sts, scl] = pspm_sf_scl(model, options)
 % ● Format
 %   [sts, scl] = pspm_sf_scl(scr, sr)
 % ● Arguments
-%   * scr    : the input skin conductance response
-%   * sr     : the input sampling rate
-%   * options: the options struct
+%   ┌────────model
+%   ├─────────.scr : skin conductance epoch (maximum size depends on computing power,
+%   │                a sensible size is 60 s at 10 Hz)
+%   ├──────────.sr : [numeric] [unit: Hz] sampling rate.
+%   └.missing_data : [Optional] missing epoch data, originally loaded as model.missing
+%                    from pspm_sf, but calculated into .missing_data (created
+%                    in pspm_sf and then transferred to pspm_sf_dcm.
+%   * options: the options struct (not used)
 % ● Outputs
 %   * scl    : scl outputs
 % ● History
@@ -22,13 +27,11 @@ end
 sts = -1;
 scl = [];
 
-
 % check input arguments
 if nargin < 1
   warning('No data specified'); return;
 end;
 try model.scr; catch, warning('Input data is not defined.'); return; end
-try model.sr; catch, warning('Sample rate is not defined.'); return; end
-scl = mean(scr);
+scl = mean(model.scr);
 sts = 1;
 

--- a/src/pspm_tam.m
+++ b/src/pspm_tam.m
@@ -120,23 +120,10 @@ tam = struct();
 if nargin < 1; errmsg = 'Nothing to do.'; warning('ID:invalid_input', errmsg); return
 elseif nargin < 2; options = struct(); end
 
-% 2.2 check model
-model = pspm_check_model(model, 'tam');
-if model.invalid
+% 2.2 check model and options
+[model, options] = pspm_check_model(model, options, 'tam');
+if model.invalid || options.invalid
     return
-end
-
-% 2.3 check options
-options = pspm_options(options, 'tam');
-if options.invalid
-  return
-end
-
-% 2.4 check files
-% stop the script if files are not allowed to overwrite
-if ~pspm_overwrite(model.modelfile, options)
-  warning('ID:invalid_input', 'Model file exists, and overwriting not allowed by user.');
-  return
 end
 
 %% Loading files


### PR DESCRIPTION
Fixes #816  .

Changes proposed in this pull request:
- consider `timeunits == 'whole'` in `pspm_check_model` 
- fix some additional issues for methods SCL and AUC

