### PR TITLE
Update Open Data and News pages

### DIFF
--- a/_posts/2024-01-05-news.md
+++ b/_posts/2024-01-05-news.md
@@ -4,6 +4,35 @@ title: News
 permalink: /news/
 ---
 
+### 04.06.2026
+
+Experiment-based calibration provides a framework for comparing the accuracy of different measurement methods, but raises new questions about statistical inference and decisions between methods. [Mancinelli & Bach (2026)](https://doi.org/10.3758/s13428-026-03042-9) show that Bayesian meta-analytic model comparison provides a suitable framework for inference in calibration and introduce a decision-theoretic approach for quantifying the economic benefits of more accurate measurement. The paper also introduces CalibR, an R package for calibration inference.
+
+---
+
+### 23.04.2026
+
+Individual differences in learning and extinction are substantial, but their neural determinants remain incompletely understood. [Gomes et al. (2026)](https://doi.org/10.1038/s41467-026-71830-0) used a large data set of more than 500 participants across fear and cognitive predictive learning paradigms to investigate whether functional, effective, and structural connectivity within a core learning network predict individual differences in learning, extinction, and renewal. Functional connectivity predicted better acquisition, while structural connectivity predicted higher levels of extinction learning, with predictive patterns generalising across learning paradigms. PsPM was used in the analysis of psychophysiological data from the fear learning paradigms.
+
+---
+
+### 22.04.2026
+
+Prediction errors (PE) are thought to drive associative learning, but it remains unclear whether they are expressed in psychophysiological responses. In a new study, [Liu et al. (2026)](https://doi.org/10.1111/psyp.70300) investigated responses to outcome occurrence and omission across skin conductance responses (SCR), pupil size responses (PSR), heart period responses (HPR), and respiration amplitude responses (RAR). Across two data sets (N = 293), all modalities showed responses to outcome omission, but there was no evidence that these responses encoded signed or unsigned prediction errors.
+
+---
+
+### 15.09.2025
+
+A new theory paper on experiment-based calibration is out. [Bach (2025)](https://doi.org/10.1016/j.jmp.2025.102950) provides a formal probability-theoretic framework for experiment-based calibration, relates the approach to classical criterion validity, and introduces a framework for modelling the data-generating process.
+
+---
+
+### 25.04.2025
+
+Pavlovian reward conditioning is used to study how humans learn and retain associations with rewarding outcomes. In a new study, [Xia, Liu et al. (2025)](https://doi.org/10.1111/psyp.70058) compared heart period responses (HPR), skin conductance responses (SCR), pupil size responses (PSR), and respiration amplitude responses (RAR) across two experiments (N = 71). Model-based HPR consistently indexed reward learning and memory retention, while model-based PSR indexed reward memory during early recall trials. The reward-conditioned HPR model will be included in PsPM 7.1.
+
+---
 ### 12.02.2025
 
 PsPM 7.0.0 released, a complete revamp of the GUI and function logic with a focus on user experience, robustness and maintainability. Backwards compatibility is partial: PsPM data files from previous versions can be read, PsPM first-level model files are can be processed with the exception of extracting segments, Matlabbatch and function calls created with previous PsPM versions require adaptation.

--- a/_posts/2024-01-06-opendata.md
+++ b/_posts/2024-01-06-opendata.md
@@ -11,9 +11,10 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 <table style="height: 121px;" border="0" width="100%">
 <tbody>
 <tr>
-	<td style="width: 12%;"><b>Name</b></td>
-	<td style="width: 44%;">First Published in</td>
-	<td style="width: 44%;">Further used in</td>
+    <td style="width: 12%;"><b>Name</b></td>
+    <td style="width: 40%;">First Published in</td>
+    <td style="width: 40%;">Further used in</td>
+	<td style="width: 8%;"><b>N</b></td>
 </tr>
 
 <tr>
@@ -21,136 +22,191 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-AOB: Eye tracker (including pupillometry) measurements from auditory oddball tasks" href="https://doi.org/10.5281/zenodo.3608706" target="_blank"><b>PsPM-AOB</b></a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp Dominik R. Bach (2016) A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision , 16:28, pp 1–16." href="https://doi.org/10.1167/16.3.28">A solid frame for the window on cognition: Modeling event-related pupil responses</a>
+		<a title="Korn CW, Bach DR (2016). A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision, 16(3):28, 1–16." href="https://doi.org/10.1167/16.3.28">Korn &amp; Bach (2016)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">66</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-BAER: Skin conductance fluctuations in a public speaking paradigm with a repeated-measures design" href="https://doi.org/10.5281/zenodo.269654" target="_blank"><b>PsPM-BAER</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Gisela Erdmann (2007) Influences of habitual and situational bodily symptom focusing on stress responses, Cognition and Emotion, 21:5, 1091-1101" href="http://dx.doi.org/10.1080/02699930600934269">Influences of habitual and situational bodily symptom focusing on stress responses</a>
+		<a title="Bach DR, Erdmann G (2007). Influences of habitual and situational bodily symptom focusing on stress responses. Cognition and Emotion, 21(5):1091–1101." href="https://doi.org/10.1080/02699930600934269">Bach &amp; Erdmann (2007)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach, Karl J. Friston, and Raymond J. Dolan. Analytic measures for quantification of arousal from spontaneous skin conductance fluctuations. International Journal of Psychophysiology, 76(1):52-55, 2010." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.011">Analytic measures for quantification of arousal from spontaneous skin conductance fluctuations</a><br />
-		<a title="Dominik R. Bach, Jean Daunizeau, Nadine Kuelzow, Karl J. Friston, and Raymond J. Dolan. Dynamic causal modeling of spontaneous fluctuations in skin conductance. Psychophysiology, 48(2):252-257, 2011." href="http://onlinelibrary.wiley.com/doi/10.1111/j.1469-8986.2010.01052.x/full">Dynamic causal modeling of spontaneous fluctuations in skin conductance</a><br />
-		<a title="Bach DR &amp; Staib M (2015). A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52(8):1106-12." href="http://onlinelibrary.wiley.com/doi/10.1111/psyp.12434/full">A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations</a>
+		<a title="Bach DR, Friston KJ, Dolan RJ (2010). Analytic measures for quantification of arousal from spontaneous skin conductance fluctuations. International Journal of Psychophysiology, 76(1):52–55." href="https://doi.org/10.1016/j.ijpsycho.2010.01.011">Bach et al. (2010)</a><br />
+		<a title="Bach DR, Daunizeau J, Kuelzow N, Friston KJ, Dolan RJ (2011). Dynamic causal modeling of spontaneous fluctuations in skin conductance. Psychophysiology, 48(2):252–257." href="https://doi.org/10.1111/j.1469-8986.2010.01052.x">Bach et al. (2011)</a><br />
+		<a title="Bach DR, Staib M (2015). A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52(8):1106–1112." href="https://doi.org/10.1111/psyp.12434">Bach &amp; Staib (2015)</a>
 	</td>
+	<td style="text-align: center;">40</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-CogSF: SCR, ECG and respiration measurements during mental arithmetic, attention, and rest" href="https://doi.org/10.5281/zenodo.3900168" target="_blank"><b>PsPM-CogSF</b></a>
+		<a title="PsPM-CogSF: SCR, ECG and respiration measurements during mental arithmetic, attention, and rest"
+		   href="https://doi.org/10.5281/zenodo.3900168"
+		   target="_blank"><b>PsPM-CogSF</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach & Matthias Staib (2015) A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52:8, pp 1106-1112." href="https://doi.org/10.1111/psyp.12434">A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations</a>
+		<a title="Bach DR, Staib M (2015). A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52(8):1106–1112."
+		   href="https://doi.org/10.1111/psyp.12434">Bach &amp; Staib (2015)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">20</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="CTX2: SCR, ECG, respiration, and startle eyeblink EMG measurements in a contextual fear conditioning task under VR with acquisition and recall test after one week" href="https://zenodo.org/records/6418684" target="_blank"><b>CTX2</b></a>
+		<a title="CTX2: SCR, ECG, respiration, and startle eyeblink EMG measurements in a contextual fear conditioning task under VR with acquisition and recall test after one week"
+		   href="https://zenodo.org/records/6418684"
+		   target="_blank"><b>CTX2</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning & Memory,30 (7), 139–150." href="https://doi.org/10.1101/lm.053781.123">Measuring human context fear conditioning and retention after consolidation</a>
+		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning &amp; Memory, 30(7):139–150."
+		   href="https://doi.org/10.1101/lm.053781.123">Xia et al. (2023)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">23</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="CTX3: SCR, ECG, respiration, and startle eyeblink EMG measurements in a contextual fear conditioning task under VR with acquisition and recall test after one week" href="https://zenodo.org/records/6418992" target="_blank"><b>CTX3</b></a>
+		<a title="CTX3: SCR, ECG, respiration, and startle eyeblink EMG measurements in a contextual fear conditioning task under VR with acquisition and recall test after one week"
+		   href="https://zenodo.org/records/6418992"
+		   target="_blank"><b>CTX3</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning & Memory,30 (7), 139–150." href="https://doi.org/10.1101/lm.053781.123">Measuring human context fear conditioning and retention after consolidation</a>
+		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning &amp; Memory, 30(7):139–150."
+		   href="https://doi.org/10.1101/lm.053781.123">Xia et al. (2023)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">28</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="CFG1: SCR, ECG, respiration, startle eyeblink EMG, and eyetracking measurements in a contextual fear conditioning task with 5 static room images with acquisition and recall test after one week" href="https://zenodo.org/records/6419011" target="_blank"><b>CFG1</b></a>
+		<a title="CFG1: SCR, ECG, respiration, startle eyeblink EMG, and eyetracking measurements in a contextual fear conditioning task with 5 static room images with acquisition and recall test after one week"
+		   href="https://zenodo.org/records/6419011"
+		   target="_blank"><b>CFG1</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning & Memory,30 (7), 139–150." href="https://doi.org/10.1101/lm.053781.123">Measuring human context fear conditioning and retention after consolidation</a>
+		<a title="Xia Y, Wehrli J, Gerster S, Kroes MCW, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning &amp; Memory, 30(7):139–150."
+		   href="https://doi.org/10.1101/lm.053781.123">Xia et al. (2023)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">29</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="CFG2: SCR, ECG, respiration, startle eyeblink EMG, and eyetracking measurements in a contextual fear conditioning task with 5 static room images with acquisition and recall test after one week" href="https://zenodo.org/records/6419020" target="_blank"><b>CFG2</b></a>
+		<a title="CFG2: SCR, ECG, respiration, startle eyeblink EMG, and eyetracking measurements in a contextual fear conditioning task with 5 static room images with acquisition and recall test after one week"
+		   href="https://zenodo.org/records/6419020"
+		   target="_blank"><b>CFG2</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Wehrli J, Gerster S, Kroes M, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning & Memory,30 (7), 139–150." href="https://doi.org/10.1101/lm.053781.123">Measuring human context fear conditioning and retention after consolidation</a>
+		<a title="Xia Y, Wehrli J, Gerster S, Kroes MCW, Houtekamer M, Bach DR (2023). Measuring human context fear conditioning and retention after consolidation. Learning &amp; Memory, 30(7):139–150."
+		   href="https://doi.org/10.1101/lm.053781.123">Xia et al. (2023)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">24</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="DoxAv1: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in an RCT using doxycycline/placebo during trace fear conditioning and retention." href="https://zenodo.org/records/6594800" target="_blank"><b>DoxAv1</b></a>
+		<a title="DoxAv1: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in an RCT using doxycycline/placebo during trace fear conditioning and retention."
+		   href="https://zenodo.org/records/6594800"
+		   target="_blank"><b>DoxAv1</b></a>
 	</td>
 	<td>
-		<a title="Wehrli J, Xia Y, Offenhammer B, Kleim B, Müller D, Bach DR (2023). Effect of the matrix metalloproteinase inhibitor doxycycline on human trace fear memory. eNeuro 9 Feb 2023, eNeuro.0243-22.2023." href="https://doi.org/10.1523/ENEURO.0243-22.2023" target="_blank">Effect of the matrix metalloproteinase inhibitor doxycycline on human trace fear memory</a>
+		<a title="Wehrli J, Xia Y, Offenhammer B, Kleim B, Müller D, Bach DR (2023). Effect of the matrix metalloproteinase inhibitor doxycycline on human trace fear memory. eNeuro, 10(2):ENEURO.0243-22.2023."
+		   href="https://doi.org/10.1523/ENEURO.0243-22.2023"
+		   target="_blank">Wehrli et al. (2023)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">97</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="DoxAv2: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in an RCT using doxycycline/placebo during configural fear conditioning and retention." href="https://zenodo.org/records/7601734" target="_blank"><b>DoxAv2</b></a>
+		<a title="DoxAv2: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in an RCT using doxycycline/placebo during configural fear conditioning and retention."
+		   href="https://zenodo.org/records/7601734"
+		   target="_blank"><b>DoxAv2</b></a>
 	</td>
 	<td>
-		<a title="Wehrli J, Xia Y, Abivardi A , Kleim B, Bach DR (2024). The impact of doxycycline on human contextual fear memory. Psychopharmacology, 241, 1065–1077." href="https://doi.org/10.1007/s00213-024-06540-w" target="_blank">The impact of doxycycline on human contextual fear memory</a>
+		<a title="Wehrli J, Xia Y, Abivardi A, Kleim B, Bach DR (2024). The impact of doxycycline on human contextual fear memory. Psychopharmacology, 241:1065–1077."
+		   href="https://doi.org/10.1007/s00213-024-06540-w"
+		   target="_blank">Wehrli et al. (2024)</a>
 	</td>
 	<td>
 	</td>
+	<td style="text-align: center;">100</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-DoxMemP: SCR, ECG and respiration measurements in a delay fear conditioning task with visual CS and electrical US." href="https://doi.org/10.5281/zenodo.1887738" target="_blank"><b>PsPM-DoxMemP</b></a>
+		<a title="PsPM-DoxMemP: SCR, ECG and respiration measurements in a delay fear conditioning task with visual CS and electrical US."
+		   href="https://doi.org/10.5281/zenodo.1887738"
+		   target="_blank"><b>PsPM-DoxMemP</b></a>
 	</td>
 	<td>
-		<a title="Saurabh Khemka &amp; Athina Tzovara &amp; Samuel Gerster &amp; Boris B. Quednow &amp; Dominik R. Bach (2016) Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54:2, pp 204-214" href="https://doi.org/10.1111/psyp.12775" target="_blank">Modeling startle eyeblink electromyogram to assess fear learning</a>
+		<a title="Khemka S, Tzovara A, Gerster S, Quednow BB, Bach DR (2017). Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54(2):204–214."
+		   href="https://doi.org/10.1111/psyp.12775"
+		   target="_blank">Khemka et al. (2017)</a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Samuel Gerster &amp; Dominik R. Bach (2017) Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54:2, pp 215-223" href="https://doi.org/10.1111/psyp.12778" target="_blank">Assessing fear learning via conditioned respiratory amplitude responses</a><br />
-		<a title="Tzovara, A., Korn, C. W., &amp; Bach, D. R. (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS computational biology, 14(8)" href=" https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Human Pavlovian fear conditioning conforms to probabilistic learning</a><br />
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Castegnetti G, Tzovara A, Staib M, Gerster S, Bach DR (2017). Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54(2):215–223."
+		   href="https://doi.org/10.1111/psyp.12778"
+		   target="_blank">Castegnetti et al. (2017)</a><br />
+		<a title="Tzovara A, Korn CW, Bach DR (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS Computational Biology, 14(8)."
+		   href="https://doi.org/10.1371/journal.pcbi.1006243"
+		   target="_blank">Tzovara et al. (2018)</a><br />
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129."
+		   href="https://doi.org/10.3758/s13428-024-02341-3"
+		   target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300."
+		   href="https://doi.org/10.1111/psyp.70300"
+		   target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">20</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-DoxMem1: SCR, ECG and respiration measurements in an RCT using doxycycline/placebo during delay fear conditioning and retention." href="https://doi.org/10.5281/zenodo.1887580" target="_blank"><b>PsPM-DoxMem1</b></a>
+		<a title="PsPM-DoxMem1: SCR, ECG and respiration measurements in an RCT using doxycycline/placebo during delay fear conditioning and retention."
+		   href="https://doi.org/10.5281/zenodo.1887580"
+		   target="_blank"><b>PsPM-DoxMem1</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Athina Tzovara &amp; Johanna Vunder (2018) Blocking human fear memory with the matrix metalloproteinase inhibitor doxycycline. Molecular Psychiatry, 23:7, pp 1584--1589" href="https://dx.doi.org/10.1038/mp.2017.65" target="_blank">Blocking human fear memory with the matrix metalloproteinase inhibitor doxycycline</a>
+		<a title="Bach DR, Tzovara A, Vunder J (2018). Blocking human fear memory with the matrix metalloproteinase inhibitor doxycycline. Molecular Psychiatry, 23(7):1584–1589."
+		   href="https://doi.org/10.1038/mp.2017.65"
+		   target="_blank">Bach et al. (2018)</a>
 	</td>
-	<td></td>
+	<td>
+	</td>
+	<td style="text-align: center;">78</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-DoxMem2: Pupil, SCR, ECG, EMG and respiration measurement in a classical pavlovian discriminant delay fear conditioning task, reminder under doxycycline/placebo, retention and re-learning" href="https://doi.org/10.5281/zenodo.3460921" target="_blank"><b>PsPM-DoxMem2</b></a>
+		<a title="PsPM-DoxMem2: Pupil, SCR, ECG, EMG and respiration measurement in a classical Pavlovian discriminant delay fear conditioning task, reminder under doxycycline/placebo, retention and re-learning"
+		   href="https://doi.org/10.5281/zenodo.3460921"
+		   target="_blank"><b>PsPM-DoxMem2</b></a>
 	</td>
 	<td>
-		<a title="Dominik R Bach &amp; Monika Näf &amp; Markus Deutschmann &amp; Shiva K. Tyagarajan &amp; Boris B. Quednow (2019) Threat memory reminder under matrix metalloproteinase 9 inhibitor doxycycline globally reduces subsequent memory plasticity. Journal of Neuroscience, 1285-19" href="https://dx.doi.org/10.1523/JNEUROSCI.1285-19.2019 " target="_blank">Threat memory reminder under matrix metalloproteinase 9 inhibitor doxycycline globally reduces subsequent memory plasticity</a>
+		<a title="Bach DR, Näf M, Deutschmann M, Tyagarajan SK, Quednow BB (2019). Threat memory reminder under matrix metalloproteinase 9 inhibitor doxycycline globally reduces subsequent memory plasticity. Journal of Neuroscience."
+		   href="https://doi.org/10.1523/JNEUROSCI.1285-19.2019"
+		   target="_blank">Bach et al. (2019)</a>
 	</td>
-	<td></td>
+	<td>
+	</td>
+	<td style="text-align: center;">79</td>
 </tr>
 
 <tr>
@@ -158,51 +214,51 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-EWO: Eye tracker (including pupillometry) measurements from emotional-words tasks" href="https://doi.org/10.5281/zenodo.4147043" target="_blank"><b>PsPM-EWO</b></a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp Dominik R. Bach (2016) A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision , 16:28, pp 1–16." href="https://doi.org/10.1167/16.3.28">A solid frame for the window on cognition: Modeling event-related pupil responses</a>
+		<a title="Korn CW, Bach DR (2016). A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision, 16(3):28, 1–16." href="https://doi.org/10.1167/16.3.28">Korn &amp; Bach (2016)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">37</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-FER01: PSR, SCR, ECG and respiration measurements from a discriminant delay fear conditioning task with visual CS and electrical US." href="https://zenodo.org/records/5650832" target="_blank"><b>PsPM-FER01</b></a>
 	</td>
 	<td>
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a>
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a>
 	</td>
 	<td>
-		<a title="Liu H, Linnell J,  Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63 (4), e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63(4):e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
 	</td>
+	<td style="text-align: center;">30</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="PsPM-FER02: PSR, SCR, ECG and respiration measurements from a 3 conditions x 3 experimental sessions repeated-measures design to assess the return of fear." href="https://zenodo.org/records/10491934" target="_blank"><b>PsPM-FER02</b></a>
+		<a title="PsPM-FER02: PSR, SCR, ECG and respiration measurements from a 3 conditions × 3 experimental sessions repeated-measures design to assess the return of fear." href="https://zenodo.org/records/10491934" target="_blank"><b>PsPM-FER02</b></a>
 	</td>
 	<td>
-		<a title="Zimmermann J, Bach DR (2020). Impact of a reminder/extinction procedure on threat-conditioned pupil size and skin conductance responses. Learning & Memory, 27, 164–172." href="https://doi.org/10.1101/lm.050211.119" target="_blank">Impact of a reminder/extinction procedure on threat-conditioned pupil size and skin conductance responses</a>
+		<a title="Zimmermann J, Bach DR (2020). Impact of a reminder/extinction procedure on threat-conditioned pupil size and skin conductance responses. Learning &amp; Memory, 27:164–172." href="https://doi.org/10.1101/lm.050211.119" target="_blank">Zimmermann &amp; Bach (2020)</a>
 	</td>
 	<td>
-			<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-			<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">74</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-FR: SCR, ECG and respiration measurements in a delay fear conditioning task with visual CS and electrical US." href="https://doi.org/10.5281/zenodo.1405394" target="_blank"><b>PsPM-FR</b></a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Philipp C. Paulus &amp; Nicolas Hofer &amp; Dominik R. Bach (2016) Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53:6, pp 930-939" href="https://doi.org/10.1111/psyp.12637" target="_blank">Modeling fear-conditioned bradycardia in humans</a>
+		<a title="Castegnetti G, Tzovara A, Staib M, Paulus PC, Hofer N, Bach DR (2016). Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53(6):930–939." href="https://doi.org/10.1111/psyp.12637" target="_blank">Castegnetti et al. (2016)</a>
 	</td>
 	<td>
-		<a title="Saurabh Khemka &amp; Athina Tzovara &amp; Samuel Gerster &amp; Boris B. Quednow &amp; Dominik R. Bach (2016) Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54:2, pp 204-214" href="https://doi.org/10.1111/psyp.12775" target="_blank">Modeling startle eyeblink electromyogram to assess fear learning</a><br />
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Samuel Gerster &amp; Dominik R. Bach (2017) Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54:2, pp 215-223" href=" https://doi.org/10.1111/psyp.12778" target="_blank">Assessing fear learning via conditioned respiratory amplitude responses</a><br />
-		<a title="Tzovara, A., Korn, C. W., &amp; Bach, D. R. (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS computational biology, 14(8)" href=" https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Human Pavlovian fear conditioning conforms to probabilistic learning</a><br />
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Khemka S, Tzovara A, Gerster S, Quednow BB, Bach DR (2017). Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54(2):204–214." href="https://doi.org/10.1111/psyp.12775" target="_blank">Khemka et al. (2017)</a><br />
+		<a title="Castegnetti G, Tzovara A, Staib M, Gerster S, Bach DR (2017). Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54(2):215–223." href="https://doi.org/10.1111/psyp.12778" target="_blank">Castegnetti et al. (2017)</a><br />
+		<a title="Tzovara A, Korn CW, Bach DR (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS Computational Biology, 14(8)." href="https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Tzovara et al. (2018)</a><br />
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">23</td>
 </tr>
 
 <tr>
@@ -210,82 +266,79 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-FSS6B: SCR and PSR measurements in a delay fear conditioning task with somatosensory CS and electrical US" href="https://doi.org/10.5281/zenodo.3601251" target="_blank"><b>PsPM-FSS6B</b></a>
 	</td>
 	<td>
-		<a title="Korn CK, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54, 330-343." href="https://doi.org/10.1111/psyp.12801" target="_blank">A pupil size response model to assess fear learning</a>
-</td>
-	<td>
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
- 		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
+		<a title="Korn CW, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54(3):330–343." href="https://doi.org/10.1111/psyp.12801" target="_blank">Korn et al. (2017)</a>
 	</td>
+	<td>
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">18</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-FSS7B: Inhibiting human aversive memory by transcranial theta-burst stimulation to primary sensory cortex" href="https://zenodo.org/records/6377103" target="_blank"><b>PsPM-FSS7B</b></a>
 	</td>
 	<td>
-		<a title="Ojala KE, Staib M, Gerster S, Ruff CC, Bach DR (2022). Inhibiting human aversive memory by transcranial theta-burst stimulation to primary sensory cortex. Biological Psychiatry, 92, 149-157." href="https://doi.org/10.1016/j.biopsych.2022.01.021" target="_blank">Inhibiting human aversive memory by transcranial theta-burst stimulation to primary sensory cortex</a>
+		<a title="Ojala KE, Staib M, Gerster S, Ruff CC, Bach DR (2022). Inhibiting human aversive memory by transcranial theta-burst stimulation to primary sensory cortex. Biological Psychiatry, 92:149–157." href="https://doi.org/10.1016/j.biopsych.2022.01.021" target="_blank">Ojala et al. (2022)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">68</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-HRA1: Skin conductance responses in fear conditioning with visual CS and electrical US" href="https://doi.org/10.5281/zenodo.321641" target="_blank"><b>PsPM-HRA1</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Jean Daunizeau &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Dynamic causal modelling of anticipatory skin conductance responses. Biological Psychology, 85:1, pp 163-170." href="https://dx.doi.org/10.1016/j.biopsycho.2010.06.007" target="_blank">Dynamic causal modelling of anticipatory skin conductance responses</a>
+		<a title="Bach DR, Daunizeau J, Friston KJ, Dolan RJ (2010). Dynamic causal modelling of anticipatory skin conductance responses. Biological Psychology, 85(1):163–170." href="https://doi.org/10.1016/j.biopsycho.2010.06.007" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td>
-		<a title="Matthias Staib &amp; Giuseppe Castegnetti &amp; Dominik R. Bach (2015) Optimising a model-based approach to inferring fear learning from skin conductance responses. Journal of Neuroscience Methods, 255, pp 131-138." href="https://dx.doi.org/10.1016/j.jneumeth.2015.08.009" target="_blank">Optimising a model-based approach to inferring fear learning from skin conductance responses</a>
+		<a title="Staib M, Castegnetti G, Bach DR (2015). Optimising a model-based approach to inferring fear learning from skin conductance responses. Journal of Neuroscience Methods, 255:131–138." href="https://doi.org/10.1016/j.jneumeth.2015.08.009" target="_blank">Staib et al. (2015)</a>
 	</td>
+	<td style="text-align: center;">20</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-HRM_IAPS: SCR, ECG and respiration measurement in response to aversive/arousing/neutral IAPS pictures" href="https://doi.org/10.5281/zenodo.2592194" target="_blank"><b>PsPM-HRM_IAPS</b></a>
 	</td>
 	<td>
-		<a title="Philipp C. Paulus &amp Giuseppe Castegnetti &amp Dominik R. Bach (2016) Modeling event-related heart period responses. Psychophysiology, 53:6, pp 837-846" href="https://doi.org/10.1111/psyp.12622" target="_blank">Modeling event-related heart period responses</a>
+		<a title="Paulus PC, Castegnetti G, Bach DR (2016). Modeling event-related heart period responses. Psychophysiology, 53(6):837–846." href="https://doi.org/10.1111/psyp.12622" target="_blank">Paulus et al. (2016)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp Samuel Gerster &amp Athina Tzovara &amp Giuseppe Castegnetti (2016) A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270, pp 147-155" href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">A linear model for event-related respiration responses</a>
+		<a title="Bach DR, Gerster S, Tzovara A, Castegnetti G (2016). A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270:147–155." href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">Bach et al. (2016)</a>
 	</td>
+	<td style="text-align: center;">23</td>
 </tr>
-
-
 <tr>
 	<td>
 		<a title="PsPM-HRM1_2: SCR and ECG measurements in response to white noise sounds and an auditory oddball task" href="https://zenodo.org/records/3836480" target="_blank"><b>PsPM-HRM1-2</b></a>
 	</td>
 	<td>
-		<a title="Philipp C. Paulus & Giuseppe Castegnetti & Dominik R. Bach (2016) Modeling event-related heart period responses. Psychophysiology, 53:6, pp 837-846." href="https://doi.org/10.1111/psyp.12622">Modeling event‐related heart period responses</a>
+		<a title="Paulus PC, Castegnetti G, Bach DR (2016). Modeling event-related heart period responses. Psychophysiology, 53(6):837–846." href="https://doi.org/10.1111/psyp.12622" target="_blank">Paulus et al. (2016)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">61</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-HRM5: SCR, ECG and respiration measurements in response to positive/negative IAPS pictures, and neutral/aversive sounds" href="https://doi.org/10.5281/zenodo.3860807" target="_blank"><b>PsPM-HRM5</b></a>
 	</td>
 	<td>
-		<a title="Philipp C. Paulus & Giuseppe Castegnetti & Dominik R. Bach (2016) Modeling event-related heart period responses. Psychophysiology, 53:6, pp 837-846." href="https://doi.org/10.1111/psyp.12622">Modeling event‐related heart period responses</a>
+		<a title="Paulus PC, Castegnetti G, Bach DR (2016). Modeling event-related heart period responses. Psychophysiology, 53(6):837–846." href="https://doi.org/10.1111/psyp.12622" target="_blank">Paulus et al. (2016)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">19</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-LI: SCR, ECG, PSR and respiration measurements in a delay fear conditioning task with auditory CS and electrical US." href="https://doi.org/10.5281/zenodo.1288494" target="_blank"><b>PsPM-LI</b></a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp; Matthias Staib &amp; Athina Tzovara &amp; Giuseppe Castegnetti &amp; Dominik R. Bach (2017) A pupil size response model to assess fear learning. Psychophysiology, 54:3, pp 330-343" href="https://doi.org/10.1111/psyp.12801" target="_blank">A pupil size response model to assess fear learning</a>
+		<a title="Korn CW, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54(3):330–343." href="https://doi.org/10.1111/psyp.12801" target="_blank">Korn et al. (2017)</a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Samuel Gerster &amp; Dominik R. Bach (2017) Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54:2, pp 215-223" href="https://doi.org/10.1111/psyp.12778" target="_blank">Assessing fear learning via conditioned respiratory amplitude responses</a>
+		<a title="Castegnetti G, Tzovara A, Staib M, Gerster S, Bach DR (2017). Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54(2):215–223." href="https://doi.org/10.1111/psyp.12778" target="_blank">Castegnetti et al. (2017)</a>
 	</td>
+	<td style="text-align: center;">20</td>
 </tr>
 
 <tr>
@@ -293,10 +346,10 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="MinAv: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in an RCT using minocycline/placebo during configural fear conditioning and retention." href="https://zenodo.org/records/7601792" target="_blank"><b>MinAv</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Wehrli J, Abivardi A , Hostiuc M, Kleim B, Bach DR (2024). Attenuating human fear memory retention with minocycline: a randomized placebo-controlled trial. Translational Psychiatry, 14, 28." href="https://doi.org/10.1038/s41398-024-02732-2" target="_blank">Attenuating human fear memory retention with minocycline: a randomized placebo-controlled trial</a>
+		<a title="Xia Y, Wehrli J, Abivardi A, Hostiuc M, Kleim B, Bach DR (2024). Attenuating human fear memory retention with minocycline: A randomized placebo-controlled trial. Translational Psychiatry, 14:28." href="https://doi.org/10.1038/s41398-024-02732-2" target="_blank">Xia et al. (2024)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">107</td>
 </tr>
 
 <tr>
@@ -304,13 +357,15 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-NK: Skin conductance fluctuations in a public speaking paradigm with a between-subjects design" href="https://doi.org/10.5281/zenodo.61718" target="_blank"><b>PsPM-NK</b></a>
 	</td>
 	<td>
-		The influence of experimentally induced anxiety on learning passive avoidance
-		<address>Nadine Kuelzow &amp; Gisela Erdmann &amp; Martin Schmidt (2004). In A. M. Oliveira &amp; M. P. Teixeira &amp; G. F. Borges &amp; M. J. Ferro (eds.), Fechner Day 2004. Proceedings of the twentieth annual meeting of the International Society for Psychophysics, pp 430-435, Coimbra:International Society for Psychophysics.</address>
+		<span title="Kuelzow N, Erdmann G, Schmidt M (2004). The influence of experimentally induced anxiety on learning passive avoidance. In Oliveira AM, Teixeira MP, Borges GF, Ferro MJ (Eds.), Fechner Day 2004. Proceedings of the Twentieth Annual Meeting of the International Society for Psychophysics, pp. 430–435." style="cursor: help;">
+			Kuelzow et al. (2004)
+		</span>
 	</td>
 	<td>
-		<a title="Dominik R. Bach, Jean Daunizeau, Nadine Kuelzow, Karl J. Friston, and Raymond J. Dolan. Dynamic causal modeling of spontaneous fluctuations in skin conductance. Psychophysiology, 48(2):252-257, 2011." href="http://onlinelibrary.wiley.com/doi/10.1111/j.1469-8986.2010.01052.x/full">Dynamic causal modeling of spontaneous fluctuations in skin conductance</a><br />
-		<a title="Bach DR &amp; Staib M (2015). A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52(8):1106-12." href="http://onlinelibrary.wiley.com/doi/10.1111/psyp.12434/full">A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations</a>
+		<a title="Bach DR, Daunizeau J, Kuelzow N, Friston KJ, Dolan RJ (2011). Dynamic causal modeling of spontaneous fluctuations in skin conductance. Psychophysiology, 48(2):252–257." href="https://doi.org/10.1111/j.1469-8986.2010.01052.x" target="_blank">Bach et al. (2011)</a><br />
+		<a title="Bach DR, Staib M (2015). A matching pursuit algorithm for inferring tonic sympathetic arousal from spontaneous skin conductance fluctuations. Psychophysiology, 52(8):1106–1112." href="https://doi.org/10.1111/psyp.12434" target="_blank">Bach &amp; Staib (2015)</a>
 	</td>
+	<td style="text-align: center;">32</td>
 </tr>
 
 <tr>
@@ -318,10 +373,10 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-PCF2: PSR, SCR, ECG, respiration and startle-eyeblink EMG measurements in a delay fear conditioning task with 4 CS and different reinforcement rates." href="https://zenodo.org/records/7313441" target="_blank"><b>PsPM-PCF2</b></a>
 	</td>
 	<td>
-	  <a title="Ojala KE, Tzovara A, Poser BA, Lutti A, Bach DR (2022). Asymmetric representation of aversive prediction errors in Pavlovian threat conditioning. Neuroimage, 263, 119579." href="https://doi.org/10.1016/j.neuroimage.2022.119579" target="_blank">Asymmetric representation of aversive prediction errors in Pavlovian threat conditioning</a>
+		<a title="Ojala KE, Tzovara A, Poser BA, Lutti A, Bach DR (2022). Asymmetric representation of aversive prediction errors in Pavlovian threat conditioning. NeuroImage, 263:119579." href="https://doi.org/10.1016/j.neuroimage.2022.119579" target="_blank">Ojala et al. (2022)</a>
 	</td>
-	<td>		
-</td>
+	<td></td>
+	<td style="text-align: center;">19</td>
 </tr>
 
 <tr>
@@ -329,33 +384,36 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-PCF3: Skin conductance, heart beat, respiration, and eyetracker recordings from a fear conditioning task with different reinforcement probabilities." href="https://zenodo.org/records/10849996" target="_blank"><b>PsPM-PCF3</b></a>
 	</td>
 	<td>
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
 	<td></td>
+	<td style="text-align: center;">31</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-PIT1 : PSR, SCR, ECG and respiration measurements from pavlovian to instrumental transfer tasks with visual CS and electrical US" href="https://doi.org/10.5281/zenodo.2641734" target="_blank"><b>PsPM-PIT1</b></a>
+		<a title="PsPM-PIT1: PSR, SCR, ECG and respiration measurements from Pavlovian-to-instrumental transfer tasks with visual CS and electrical US." href="https://doi.org/10.5281/zenodo.2641734" target="_blank"><b>PsPM-PIT1</b></a>
 	</td>
 	<td>
-		<a title="Yanfang Xia &amp; Angelina Gurkina &amp; Dominik R. Bach (2019). Pavlovian-to-instrumental transfer after human threat conditioning. Learning &amp Memory, 26(5), pp 167-175" href="https://doi.org/10.1101/lm.049338.119" target="_blank">Pavlovian-to-instrumental transfer after human threat conditioning</a>
+		<a title="Xia Y, Gurkina A, Bach DR (2019). Pavlovian-to-instrumental transfer after human threat conditioning. Learning &amp; Memory, 26(5):167–175." href="https://doi.org/10.1101/lm.049338.119" target="_blank">Xia et al. (2019)</a>
 	</td>
 	<td>
-			<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: an index for human threat conditioning. Behavior Research Methods, 53, 1426-1439. " href="https://doi.org/10.3758/s13428-020-01490-5">Saccadic scanpath length: an index for human threat conditioning.</a>
-</td>
+		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: An index for human threat conditioning. Behavior Research Methods, 53:1426–1439." href="https://doi.org/10.3758/s13428-020-01490-5" target="_blank">Xia et al. (2020)</a>
+	</td>
+	<td style="text-align: center;">22</td>
 </tr>
 
 <tr>
 	<td>
-		<a title="PsPM-PIT2 : PSR, SCR, ECG and respiration measurements from pavlovian to instrumental transfer tasks with visual CS and electrical US" href="https://doi.org/10.5281/zenodo.2641738" target="_blank"><b>PsPM-PIT2</b></a>
+		<a title="PsPM-PIT2: PSR, SCR, ECG and respiration measurements from Pavlovian-to-instrumental transfer tasks with visual CS and electrical US." href="https://doi.org/10.5281/zenodo.2641738" target="_blank"><b>PsPM-PIT2</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Gurkina A & Bach DR (2019). Pavlovian-to-instrumental transfer after human threat conditioning. Learning & Memory, 26(5):167-175." href="https://doi.org/10.1101/lm.049338.119" target="_blank">Pavlovian-to-instrumental transfer after human threat conditioning</a>
+		<a title="Xia Y, Gurkina A, Bach DR (2019). Pavlovian-to-instrumental transfer after human threat conditioning. Learning &amp; Memory, 26(5):167–175." href="https://doi.org/10.1101/lm.049338.119" target="_blank">Xia et al. (2019)</a>
 	</td>
-	<td>		
-	<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: an index for human threat conditioning. Behavior Research Methods, 53, 1426-1439. " href="https://doi.org/10.3758/s13428-020-01490-5">Saccadic scanpath length: an index for human threat conditioning.</a>
-</td>
+	<td>
+		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: An index for human threat conditioning. Behavior Research Methods, 53:1426–1439." href="https://doi.org/10.3758/s13428-020-01490-5" target="_blank">Xia et al. (2020)</a>
+	</td>
+	<td style="text-align: center;">38</td>
 </tr>
 
 <tr>
@@ -363,81 +421,82 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-PubFe: Pupil size response in a delay fear conditioning procedure with auditory CS and electrical US" href="https://doi.org/10.5281/zenodo.1168493" target="_blank"><b>PsPM-PubFe</b></a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp; Matthias Staib &amp; Athina Tzovara &amp; Giuseppe Castegnetti &amp; Dominik R. Bach (2017) A pupil size response model to assess fear learning. Psychophysiology, 54:3, pp 330-343" href="https://dx.doi.org/10.1111/psyp.12801" target="_blank">A pupil size response model to assess fear learning</a>
+		<a title="Korn CW, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54(3):330–343." href="https://doi.org/10.1111/psyp.12801" target="_blank">Korn et al. (2017)</a>
 	</td>
 	<td>
-		<a title="Tzovara, A., Korn, C. W., &amp; Bach, D. R. (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS computational biology, 14(8)" href=" https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Human Pavlovian fear conditioning conforms to probabilistic learning</a>
-		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: an index for human threat conditioning. Behavior Research Methods, 53, 1426-1439. " href="https://doi.org/10.3758/s13428-020-01490-5">Saccadic scanpath length: an index for human threat conditioning.</a>
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Tzovara A, Korn CW, Bach DR (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS Computational Biology, 14(8)." href="https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Tzovara et al. (2018)</a><br />
+		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: An index for human threat conditioning. Behavior Research Methods, 53:1426–1439." href="https://doi.org/10.3758/s13428-020-01490-5" target="_blank">Xia et al. (2020)</a><br />
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">22</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-REW1: SCR, ECG, respiration, and eyetracking measurements in a Pavlovian appetitive conditioning task with juice delivery with acquisition and recall test after one week." href="https://zenodo.org/records/12580447" target="_blank"><b>PsPM-REW1</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Liu H, Kälin OK, Gerster S, Bach DR (2025). Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation. Psychophysiology, 62, e70058." href="https://doi.org/10.1111/psyp.70058" target="_blank">Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation</a>
+		<a title="Xia Y, Liu H, Kälin OK, Gerster S, Bach DR (2025). Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation. Psychophysiology, 62:e70058." href="https://doi.org/10.1111/psyp.70058" target="_blank">Xia et al. (2025)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">37</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-REW2: SCR, ECG, respiration, and eyetracking measurements in a Pavlovian appetitive conditioning task with juice delivery with acquisition and recall test after one week." href="https://zenodo.org/records/12580464" target="_blank"><b>PsPM-REW2</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Liu H, Kälin OK, Gerster S, Bach DR (2025). Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation. Psychophysiology, 62, e70058." href="https://doi.org/10.1111/psyp.70058" target="_blank">Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation</a>
+		<a title="Xia Y, Liu H, Kälin OK, Gerster S, Bach DR (2025). Measuring Human Pavlovian Reward Conditioning and Memory Retention After Consolidation. Psychophysiology, 62:e70058." href="https://doi.org/10.1111/psyp.70058" target="_blank">Xia et al. (2025)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">34</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-RRM1-2: SCR, ECG and respiration measurement in response to electric stimulation or visual targets" href="https://doi.org/10.5281/zenodo.3405226" target="_blank"><b>PsPM-RRM1-2</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Samuel Gerster &amp; Athina Tzovara &amp; Giuseppe Castegnetti (2016) A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270, pp 147-155" href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">A linear model for event-related respiration responses</a>
+		<a title="Bach DR, Gerster S, Tzovara A, Castegnetti G (2016). A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270:147–155." href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">Bach et al. (2016)</a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp Dominik R. Bach (2016) A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision , 16:28, pp 1–16." href="https://doi.org/10.1167/16.3.28">A solid frame for the window on cognition: Modeling event-related pupil responses</a>
+		<a title="Korn CW, Bach DR (2016). A solid frame for the window on cognition: Modeling event-related pupil responses. Journal of Vision, 16(3):28, 1–16." href="https://doi.org/10.1167/16.3.28" target="_blank">Korn &amp; Bach (2016)</a>
 	</td>
+	<td style="text-align: center;">29</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-RRM3: SCR, ECG and respiration measurement in response to aversive/arousing IAPS pictures, and neutral/aversive sounds" href="https://doi.org/10.5281/zenodo.3428709" target="_blank"><b>PsPM-RRM3</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Samuel Gerster &amp; Athina Tzovara &amp; Giuseppe Castegnetti (2016) A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270, pp 147-155" href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">A linear model for event-related respiration responses</a>
+		<a title="Bach DR, Gerster S, Tzovara A, Castegnetti G (2016). A linear model for event-related respiration responses. Journal of Neuroscience Methods, 270:147–155." href="https://doi.org/10.1016/j.jneumeth.2016.06.001" target="_blank">Bach et al. (2016)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">20</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SC2F: SCR, ECG, PPU and respiration measurements from a delay fear conditioning task with auditory CS, performed during MRI scanning" href="https://doi.org/10.5281/zenodo.4045656" target="_blank"><b>PsPM-SC2F</b></a>
 	</td>
 	<td>
-		<a title="Matthias Staib & Dominik R. Bach (2018) Stimulus-invariant auditory cortex threat encoding during fear conditioning with simple and complex sounds. NeuroImage, 166, pp 276-284, Elsevier Science." href="https://doi.org/10.1016/j.neuroimage.2017.11.009">Stimulus-invariant auditory cortex threat encoding during fear conditioning with simple and complex sounds</a>
+		<a title="Staib M, Bach DR (2018). Stimulus-invariant auditory cortex threat encoding during fear conditioning with simple and complex sounds. NeuroImage, 166:276–284." href="https://doi.org/10.1016/j.neuroimage.2017.11.009" target="_blank">Staib &amp; Bach (2018)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">18</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SC4B: SCR, ECG, EMG, PSR and respiration measurements in a delay fear conditioning task with auditory CS and electrical US" href="https://doi.org/10.5281/zenodo.1039580" target="_blank"><b>PsPM-SC4B</b></a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Philipp C. Paulus &amp; Nicolas Hofer &amp; Dominik R. Bach (2016) Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53:6, pp 930-939." href="https://dx.doi.org/10.1111/psyp.12637" target="_blank">Modeling fear-conditioned bradycardia in humans</a>
+		<a title="Castegnetti G, Tzovara A, Staib M, Paulus PC, Hofer N, Bach DR (2016). Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53(6):930–939." href="https://doi.org/10.1111/psyp.12637" target="_blank">Castegnetti et al. (2016)</a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp; Matthias Staib &amp; Athina Tzovara &amp; Giuseppe Castegnetti &amp; Dominik R. Bach (2017) A pupil size response model to assess fear learning. Psychophysiology, 54:3, pp 330-343." href="https://dx.doi.org/10.1111/psyp.12801" target="_blank">A pupil size response model to assess fear learning</a><br /><a href="https://doi.org/10.1016/j.neuroimage.2017.11.009">Stimulus-invariant auditory cortex threat encoding during fear conditioning with simple and complex sounds</a><br />
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Korn CW, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54(3):330–343." href="https://doi.org/10.1111/psyp.12801" target="_blank">Korn et al. (2017)</a><br />
+		<a title="Staib M, Bach DR (2018). Stimulus-invariant auditory cortex threat encoding during fear conditioning with simple and complex sounds. NeuroImage, 166:276–284." href="https://doi.org/10.1016/j.neuroimage.2017.11.009" target="_blank">Staib &amp; Bach (2018)</a><br />
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">21</td>
 </tr>
 
 <tr>
@@ -445,120 +504,120 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-SCBD: Skin conductance response from a delay fear conditioning task with auditory CS (monophones/triads)" href="https://doi.org/10.5281/zenodo.4115079" target="_blank"><b>PsPM-SCBD</b></a>
 	</td>
 	<td>
-		<a title="Matthias Staib & Giuseppe Castegnetti & Dominik R. Bach (2015) Optimising a model-based approach to inferring fear learning from skin conductance responses. Journal of Neuroscience Methods, 255, pp 131-138." href="https://doi.org/10.1016/j.jneumeth.2015.08.009">Optimising a model-based approach to inferring fear learning from skin conductance responses</a>
+		<a title="Staib M, Castegnetti G, Bach DR (2015). Optimising a model-based approach to inferring fear learning from skin conductance responses. Journal of Neuroscience Methods, 255:131–138." href="https://doi.org/10.1016/j.jneumeth.2015.08.009" target="_blank">Staib et al. (2015)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">10</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCB2D: Skin conductance response from a delay fear conditioning task with auditory CS (monophones/triads)" href="https://doi.org/10.5281/zenodo.4071223" target="_blank"><b>PsPM-SCB2D</b></a>
 	</td>
 	<td>
-		<a title="Matthias Staib & Aslan Abivardi & Dominik R. Bach (2019) Primary auditory cortex representation of fear-conditioned musical sounds. Human Brain Mapping, 41:4, pp 882-891, Wiley Periodicals, Inc." href="https://doi.org/10.1002/hbm.24846">Primary auditory cortex representation of fear-conditioned musical sounds</a>
+		<a title="Staib M, Abivardi A, Bach DR (2020). Primary auditory cortex representation of fear-conditioned musical sounds. Human Brain Mapping, 41(4):882–891." href="https://doi.org/10.1002/hbm.24846" target="_blank">Staib et al. (2020)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">22</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV1: Skin conductance responses to aversive/neutral pictures at different inter trial intervals." href="https://doi.org/10.5281/zenodo.269659" target="_blank"><b>PsPM-SCRV1</b></a>
 	</td>
 	<td>
-		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of neuroscience methods, 184(2):224-234." href="http://dx.doi.org/10.1016/j.jneumeth.2009.08.005">Time-series analysis for rapid event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of Neuroscience Methods, 184(2):224–234." href="https://doi.org/10.1016/j.jneumeth.2009.08.005" target="_blank">Bach et al. (2009)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">24</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV2: Skin conductance responses to loud sounds at different inter trial intervals." href="https://doi.org/10.5281/zenodo.274919" target="_blank"><b>PsPM-SCRV2</b></a>
 	</td>
 	<td>
-		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of neuroscience methods, 184(2):224-234." href="http://dx.doi.org/10.1016/j.jneumeth.2009.08.005">Time-series analysis for rapid event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of Neuroscience Methods, 184(2):224–234." href="https://doi.org/10.1016/j.jneumeth.2009.08.005" target="_blank">Bach et al. (2009)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">24</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV3: Skin conductance responses to loud sounds and aversive/neutral pictures." href="https://doi.org/10.5281/zenodo.274963" target="_blank"><b>PsPM-SCRV3</b></a>
 	</td>
 	<td>
-		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of neuroscience methods, 184(2):224-234." href="http://dx.doi.org/10.1016/j.jneumeth.2009.08.005">Time-series analysis for rapid event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2009). Time-series analysis for rapid event-related skin conductance responses. Journal of Neuroscience Methods, 184(2):224–234." href="https://doi.org/10.1016/j.jneumeth.2009.08.005" target="_blank">Bach et al. (2009)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">22</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV4: Skin conductance responses in fear conditioning with visual CS and auditory US" href="https://doi.org/10.5281/zenodo.274992" target="_blank"><b>PsPM-SCRV4</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Jean Daunizeau &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Dynamic causal modelling of anticipatory skin conductance responses. Biological Psychology, 85:1, pp 163-170." href="https://dx.doi.org/10.1016/j.biopsycho.2010.06.007">Dynamic causal modelling of anticipatory skin conductance responses</a>
+		<a title="Bach DR, Daunizeau J, Friston KJ, Dolan RJ (2010). Dynamic causal modelling of anticipatory skin conductance responses. Biological Psychology, 85(1):163–170." href="https://doi.org/10.1016/j.biopsycho.2010.06.007" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">32</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV5: Skin conductance responses to auditory oddballs" href="https://doi.org/10.5281/zenodo.291445" target="_blank"><b>PsPM-SCRV5</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Guillaume Flandin &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75, pp 349-356." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.005">Modelling event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2010). Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75(3):349–356." href="https://doi.org/10.1016/j.ijpsycho.2010.01.005" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">20</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SCRV6: Skin conductance responses to pain by electric stimulation" href="https://doi.org/10.5281/zenodo.291446" target="_blank"><b>PsPM-SCRV6</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Guillaume Flandin &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75, pp 349-356." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.005">Modelling event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2010). Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75(3):349–356." href="https://doi.org/10.1016/j.ijpsycho.2010.01.005" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">20</td>
 </tr>
 <tr>
 	<td>
 		<a title="PsPM-SCRV7: Skin conductance responses to white noise sounds in quick succession" href="https://doi.org/10.5281/zenodo.291448" target="_blank"><b>PsPM-SCRV7</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Guillaume Flandin &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75, pp 349-356." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.005">Modelling event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2010). Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75(3):349–356." href="https://doi.org/10.1016/j.ijpsycho.2010.01.005" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">22</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="PsPM-SCRV9: Skin conductance responses to visual targets" href="https://doi.org/10.5281/zenodo.291449" target="_blank"><b>PsPM-SCRV9</b></a></td>
+		<a title="PsPM-SCRV9: Skin conductance responses to visual targets" href="https://doi.org/10.5281/zenodo.291449" target="_blank"><b>PsPM-SCRV9</b></a>
+	</td>
 	<td>
-		<a title="Dominik R. Bach &amp; Guillaume Flandin &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75, pp 349-356." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.005">Modelling event-related skin conductance responses</a>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2010). Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75(3):349–356." href="https://doi.org/10.1016/j.ijpsycho.2010.01.005" target="_blank">Bach et al. (2010)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">22</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="PsPM-SCRV10: Skin conductance responses to loud sounds, simultanously recorded from palm, fingers and foot" href="https://doi.org/10.5281/zenodo.291465" target="_blank"><b>PsPM-SCRV10</b></a></td>
-	<td>
-		<a title="Dominik R. Bach &amp; Guillaume Flandin &amp; Karl J. Friston &amp; Raymond J. Dolan (2010) Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75, pp 349-356." href="http://dx.doi.org/10.1016/j.ijpsycho.2010.01.005">Modelling event-related skin conductance responses</a>
+		<a title="PsPM-SCRV10: Skin conductance responses to loud sounds, simultaneously recorded from palm, fingers and foot" href="https://doi.org/10.5281/zenodo.291465" target="_blank"><b>PsPM-SCRV10</b></a>
 	</td>
-	<!--Further Publications-->
+	<td>
+		<a title="Bach DR, Flandin G, Friston KJ, Dolan RJ (2010). Modelling event-related skin conductance responses. International Journal of Psychophysiology, 75(3):349–356." href="https://doi.org/10.1016/j.ijpsycho.2010.01.005" target="_blank">Bach et al. (2010)</a>
+	</td>
 	<td></td>
+	<td style="text-align: center;">26</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SF: SCR, ECG, PPU and respiration measurements from a delay fear conditioning task with auditory CS (monophones/triads), performed during MRI scanning" href="https://doi.org/10.5281/zenodo.4059297" target="_blank"><b>PsPM-SF</b></a>
 	</td>
 	<td>
-		<a title="Matthias Staib & Aslan Abivardi & Dominik R. Bach (2019) Primary auditory cortex representation of fear-conditioned musical sounds. Human Brain Mapping, 41:4, pp 882-891, Wiley Periodicals, Inc." href="https://doi.org/10.1002/hbm.24846">Primary auditory cortex representation of fear-conditioned musical sounds</a>
+		<a title="Staib M, Abivardi A, Bach DR (2020). Primary auditory cortex representation of fear-conditioned musical sounds. Human Brain Mapping, 41(4):882–891." href="https://doi.org/10.1002/hbm.24846" target="_blank">Staib et al. (2020)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">20</td>
 </tr>
 
 <tr>
@@ -566,96 +625,93 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-SMD: SCR, EMG, ECG, and respiration measurement in response to auditory startle probes" href="https://doi.org/10.5281/zenodo.3430920" target="_blank"><b>PsPM-SMD</b></a>
 	</td>
 	<td>
-		<a title="Saurabh Khemka &amp Athina Tzovara &amp Samuel Gerster &amp Boris B. Quednow &amp Dominik R. Bach (2016) Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54:2, pp 204-214" href="https://doi.org/10.1111/psyp.12775" target="_blank"> Modeling startle eyeblink electromyogram to assess fear learning</a>
+		<a title="Khemka S, Tzovara A, Gerster S, Quednow BB, Bach DR (2017). Modeling startle eyeblink electromyogram to assess fear learning. Psychophysiology, 54(2):204–214." href="https://doi.org/10.1111/psyp.12775" target="_blank">Khemka et al. (2017)</a>
 	</td>
 	<td></td>
+	<td style="text-align: center;">19</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SSNA_1-2: Sudomotor Nerve Activity and Skin Conductance Response to 1: Aversive Sounds and 2: Auditory Oddballs" href="https://doi.org/10.5281/zenodo.3865363" target="_blank"><b>PsPM-SSNA_1-2</b></a>
 	</td>
 	<td>
-		<a title="Samuel Gerster & Barbara Namer & Mikael Elam & Dominik R. Bach (2017) Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation. Psychophysiology, 55:2, pp 1-10." href=" https://doi.org/10.1111/psyp.12986">Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation</a>
+		<a title="Gerster S, Namer B, Elam M, Bach DR (2018). Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation. Psychophysiology, 55(2):1–10." href="https://doi.org/10.1111/psyp.12986" target="_blank">Gerster et al. (2018)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">7</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-SSNA_3: Skin conductance response to stimulation of the peripheral median nerve with electrical impulses" href="https://doi.org/10.5281/zenodo.3891581" target="_blank"><b>PsPM-SSNA_3</b></a>
 	</td>
 	<td>
-		<a title="Klaus Kirnö & Masanari Kunimoto & Stefan Lundin & Mikael Elam & B. Gunnar Wallin (1991) Can Galvanic Skin Response Be Used as a Quantitative Estimate of Sympathetic Nerve Activity in Regional Anesthesia?. Anesthesia & Analgesia, 73:2, pp 138-142." href="https://doi.org/10.1213/00000539-199108000-00006">Can Galvanic Skin Response Be Used as a Quantitative Estimate of Sympathetic Nerve Activity in Regional Anesthesia?</a>
+		<a title="Kirnö K, Kunimoto M, Lundin S, Elam M, Wallin BG (1991). Can galvanic skin response be used as a quantitative estimate of sympathetic nerve activity in regional anesthesia? Anesthesia &amp; Analgesia, 73(2):138–142." href="https://doi.org/10.1213/00000539-199108000-00006" target="_blank">Kirnö et al. (1991)</a>
 	</td>
 	<td>
-		<a title="Masanari Kunimoto & Klaus Kirnö & Mikael Elam & B. Gunnar Wallin (1991) Neuroeffector characteristics of sweat glands in the human hand activated by regular neural stimuli. The Journal of Physiology, 442." href="https://doi.org/10.1113/jphysiol.1991.sp018799">Neuroeffector characteristics of sweat glands in the human hand activated by regular neural stimuli</a>
-		<br />
-		<a title="Samuel Gerster & Barbara Namer & Mikael Elam & Dominik R. Bach (2017) Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation. Psychophysiology, 55:2, pp 1-10." href="https://doi.org/10.1111/psyp.12986">Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation</a>
+		<a title="Kunimoto M, Kirnö K, Elam M, Wallin BG (1991). Neuroeffector characteristics of sweat glands in the human hand activated by regular neural stimuli. The Journal of Physiology, 442." href="https://doi.org/10.1113/jphysiol.1991.sp018799" target="_blank">Kunimoto et al. (1991)</a><br />
+		<a title="Gerster S, Namer B, Elam M, Bach DR (2018). Testing a linear time invariant model for skin conductance responses by intraneural recording and stimulation. Psychophysiology, 55(2):1–10." href="https://doi.org/10.1111/psyp.12986" target="_blank">Gerster et al. (2018)</a>
 	</td>
+	<td style="text-align: center;">4</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-TC: SCR, ECG, EMG and respiration measurements in a discriminant trace fear conditioning task with visual CS and electrical US." href="https://doi.org/10.5281/zenodo.1404810" target="_blank"><b>PsPM-TC</b></a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Philipp C. Paulus &amp; Nicolas Hofer &amp; Dominik R. Bach (2016) Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53:6, pp 930-939." href="https://dx.doi.org/10.1111/psyp.12637">Modeling fear-conditioned bradycardia in humans</a>
+		<a title="Castegnetti G, Tzovara A, Staib M, Paulus PC, Hofer N, Bach DR (2016). Modeling fear-conditioned bradycardia in humans. Psychophysiology, 53(6):930–939." href="https://doi.org/10.1111/psyp.12637" target="_blank">Castegnetti et al. (2016)</a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti &amp; Athina Tzovara &amp; Matthias Staib &amp; Samuel Gerster &amp; Dominik R. Bach (2017) Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54:2, pp 215-223" href=" https://doi.org/10.1111/psyp.12778" target="_blank">Assessing fear learning via conditioned respiratory amplitude responses</a><br />
-		<a title="Tzovara, A., Korn, C. W., &amp; Bach, D. R. (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS computational biology, 14(8)" href=" https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Human Pavlovian fear conditioning conforms to probabilistic learning</a>
-		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a>
-</td>
+		<a title="Castegnetti G, Tzovara A, Staib M, Gerster S, Bach DR (2017). Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54(2):215–223." href="https://doi.org/10.1111/psyp.12778" target="_blank">Castegnetti et al. (2017)</a><br />
+		<a title="Tzovara A, Korn CW, Bach DR (2018). Human Pavlovian fear conditioning conforms to probabilistic learning. PLoS Computational Biology, 14(8)." href="https://doi.org/10.1371/journal.pcbi.1006243" target="_blank">Tzovara et al. (2018)</a><br />
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a>
+	</td>
+	<td style="text-align: center;">18</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="TFC1: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in a trace fear conditioning task with acquisition and recall test after one week." href="https://zenodo.org/records/6024202" target="_blank"><b>TCF1</b></a>
+		<a title="TCF1: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in a trace fear conditioning task with acquisition and recall test after one week." href="https://zenodo.org/records/6024202" target="_blank"><b>TCF1</b></a>
 	</td>
 	<td>
-		<a title="Wehrli JM, Xia Y, Gerster S, & Bach DR (2022). Measuring human trace fear conditioning. Psychophysiology, 59, e14119." href="https://doi.org/10.1111/psyp.14119">Measuring human trace fear conditioning</a>
+		<a title="Wehrli JM, Xia Y, Gerster S, Bach DR (2022). Measuring human trace fear conditioning. Psychophysiology, 59:e14119." href="https://doi.org/10.1111/psyp.14119" target="_blank">Wehrli et al. (2022)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">28</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="TFC2: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in a trace fear conditioning task with acquisition and recall test after one week." href="https://zenodo.org/records/6024245" target="_blank"><b>TFC2</b></a>
+		<a title="TCF2: SCR, ECG, respiration, startle eyeblink EMG and eyetracking measurements in a trace fear conditioning task with acquisition and recall test after one week." href="https://zenodo.org/records/6024245" target="_blank"><b>TCF2</b></a>
 	</td>
 	<td>
-		<a title="Wehrli JM, Xia Y, Gerster S, & Bach DR (2022). Measuring human trace fear conditioning. Psychophysiology, 59, e14119." href="https://doi.org/10.1111/psyp.14119">Measuring human trace fear conditioning</a>
+		<a title="Wehrli JM, Xia Y, Gerster S, Bach DR (2022). Measuring human trace fear conditioning. Psychophysiology, 59:e14119." href="https://doi.org/10.1111/psyp.14119" target="_blank">Wehrli et al. (2022)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">28</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-trSP1: SCR, and heart beat measurement in response to aversive/neutral IAPS pictures while subjected to auditory distractors" href="https://doi.org/10.5281/zenodo.3515884" target="_blank"><b>PsPM-trSP1</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp Karl J. Friston &amp Raymond J. Dolan (2013) An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94:3, pp 490-497" href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">An improved algorithm for model-based analysis of evoked skin conductance responses</a>
+		<a title="Bach DR, Friston KJ, Dolan RJ (2013). An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94(3):490–497." href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">Bach et al. (2013)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach (2014) A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103, pp 63-68" href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis</a><br />
-		<a title="Dominik R. Bach &amp Erich Seifritz &amp Raymond J. Dolan (2015) Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images. PLoS One, 10:6, pp 1-14" href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images</a>
+		<a title="Bach DR (2014). A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103:63–68." href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">Bach (2014)</a><br />
+		<a title="Bach DR, Seifritz E, Dolan RJ (2015). Temporally unpredictable sounds exert a context-dependent influence on evaluation of unrelated images. PLoS ONE, 10(6):1–14." href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Bach et al. (2015)</a>
 	</td>
+	<td style="text-align: center;">60</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-trSP2: SCR measurement in response to aversive/arousing/neutral IAPS pictures while subjected to auditory distractors" href="https://doi.org/10.5281/zenodo.3515939" target="_blank"><b>PsPM-trSP2</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp Karl J. Friston &amp Raymond J. Dolan (2013) An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94:3, pp 490-497" href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">An improved algorithm for model-based analysis of evoked skin conductance responses</a>
+		<a title="Bach DR, Friston KJ, Dolan RJ (2013). An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94(3):490–497." href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">Bach et al. (2013)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach (2014) A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103, pp 63-68" href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis</a><br />
-		<a title="Dominik R. Bach &amp Erich Seifritz &amp Raymond J. Dolan (2015) Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images. PLoS One, 10:6, pp 1-14" href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images</a>
+		<a title="Bach DR (2014). A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103:63–68." href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">Bach (2014)</a><br />
+		<a title="Bach DR, Seifritz E, Dolan RJ (2015). Temporally unpredictable sounds exert a context-dependent influence on evaluation of unrelated images. PLoS ONE, 10(6):1–14." href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Bach et al. (2015)</a>
 	</td>
+	<td style="text-align: center;">40</td>
 </tr>
 
 <tr>
@@ -663,58 +719,58 @@ Fear conditioning data sets are provided in a standardised format to facilitate 
 		<a title="PsPM-trSP3: SCR measurement in response to aversive/arousing/neutral IAPS pictures while subjected to auditory distractors" href="https://doi.org/10.5281/zenodo.3611484" target="_blank"><b>PsPM-trSP3</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp Karl J. Friston &amp Raymond J. Dolan (2013) An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94:3, pp 490-497" href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">An improved algorithm for model-based analysis of evoked skin conductance responses</a>
+		<a title="Bach DR, Friston KJ, Dolan RJ (2013). An improved algorithm for model-based analysis of evoked skin conductance responses. Biological Psychology, 94(3):490–497." href="https://doi.org/10.1016/j.biopsycho.2013.09.010" target="_blank">Bach et al. (2013)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach (2014) A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103, pp 63-68" href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis</a><br />
-		<a title="Dominik R. Bach &amp Erich Seifritz &amp Raymond J. Dolan (2015) Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images. PLoS One, 10:6, pp 1-14" href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images</a>
+		<a title="Bach DR (2014). A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103:63–68." href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">Bach (2014)</a><br />
+		<a title="Bach DR, Seifritz E, Dolan RJ (2015). Temporally unpredictable sounds exert a context-dependent influence on evaluation of unrelated images. PLoS ONE, 10(6):1–14." href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Bach et al. (2015)</a>
 	</td>
+	<td style="text-align: center;">40</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="PsPM-trSP4: SCR measurement in response to face photographs withangry, neutral, and fearful expression while subjected to auditory distractors" href="https://doi.org/10.5281/zenodo.3611490" target="_blank"><b>PsPM-trSP4</b></a>
+		<a title="PsPM-trSP4: SCR measurement in response to face photographs with angry, neutral, and fearful expressions while subjected to auditory distractors" href="https://doi.org/10.5281/zenodo.3611490" target="_blank"><b>PsPM-trSP4</b></a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach (2014) A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103, pp 63-68" href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis</a><br />
+		<a title="Bach DR (2014). A head-to-head comparison of SCRalyze and Ledalab, two model-based methods for skin conductance analysis. Biological Psychology, 103:63–68." href="https://doi.org/10.1016/j.biopsycho.2014.08.006" target="_blank">Bach (2014)</a>
 	</td>
 	<td>
-		<a title="Dominik R. Bach &amp Erich Seifritz &amp Raymond J. Dolan (2015) Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images. PLoS One, 10:6, pp 1-14" href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Temporally Unpredictable Sounds Exert a Context-Dependent Influence on Evaluation of Unrelated Images</a>
+		<a title="Bach DR, Seifritz E, Dolan RJ (2015). Temporally unpredictable sounds exert a context-dependent influence on evaluation of unrelated images. PLoS ONE, 10(6):1–14." href="https://doi.org/10.1371/journal.pone.0131065" target="_blank">Bach et al. (2015)</a>
 	</td>
+	<td style="text-align: center;">42</td>
 </tr>
-
 <tr>
 	<td>
-		<a title="PsPM-VC1F: SCR, ECG, PPU, respiration and pupil measurements delay from a fear conditioning task with visual CS, performed during MRI scanning" href="https://doi.org/10.5281/zenodo.3980837" target="_blank"><b>PsPM-VC1F</b></a>
+		<a title="PsPM-VC1F: SCR, ECG, PPU, respiration and pupil measurements from a delay fear conditioning task with visual CS, performed during MRI scanning" href="https://doi.org/10.5281/zenodo.3980837" target="_blank"><b>PsPM-VC1F</b></a>
 	</td>
 	<td>
-		<a title="Giuseppe Castegnetti & Athina Tzovara & Matthias Staib & Samuel Gerster & Dominik R. Bach (2017) Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54:2, pp 215-223." href="https://doi.org/10.1111/psyp.12778">Assessing fear learning via conditioned respiratory amplitude responses</a>
+		<a title="Castegnetti G, Tzovara A, Staib M, Gerster S, Bach DR (2017). Assessing fear learning via conditioned respiratory amplitude responses. Psychophysiology, 54(2):215–223." href="https://doi.org/10.1111/psyp.12778" target="_blank">Castegnetti et al. (2017)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">21</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-VC7B: SCR, ECG, EMG, PSR and respiration measurements in a delay fear conditioning task with visual CS and electrical US" href="https://doi.org/10.5281/zenodo.1211610" target="_blank"><b>PsPM-VC7B</b></a>
 	</td>
 	<td>
-		<a title="Christoph W. Korn &amp; Matthias Staib &amp; Athina Tzovara &amp; Giuseppe Castegnetti &amp; Dominik R. Bach (2017) A pupil size response model to assess fear learning. Psychophysiology, 54:3, pp 330-343" href="https://dx.doi.org/10.1111/psyp.12801" target="_blank">A pupil size response model to assess fear learning</a>
-</td>
-	<td>		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Huaiyu L, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56, 6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Dimensionality and optimal combination of autonomic fear-conditioning measures in humans</a><br />
-		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63, e70300." href=" https://doi.org/10.1111/psyp.70300" target="_blank">Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis</a>
-</td>
+		<a title="Korn CW, Staib M, Tzovara A, Castegnetti G, Bach DR (2017). A pupil size response model to assess fear learning. Psychophysiology, 54(3):330–343." href="https://doi.org/10.1111/psyp.12801" target="_blank">Korn et al. (2017)</a>
+	</td>
+	<td>
+		<a title="Mancinelli F, Sporrer JK, Myrov V, Melinscak F, Zimmermann J, Liu H, Bach DR (2024). Dimensionality and optimal combination of autonomic fear-conditioning measures in humans. Behavior Research Methods, 56:6119–6129." href="https://doi.org/10.3758/s13428-024-02341-3" target="_blank">Mancinelli et al. (2024)</a><br />
+		<a title="Liu H, Linnell J, Bach DR (2026). Psychophysiological Outcome Responses in Human Pavlovian Fear Conditioning: A Prediction Error Analysis. Psychophysiology, 63:e70300." href="https://doi.org/10.1111/psyp.70300" target="_blank">Liu et al. (2026)</a>
+	</td>
+	<td style="text-align: center;">21</td>
 </tr>
-
 <tr>
 	<td>
 		<a title="PsPM-VIS: SCR, ECG, respiration and eyetracker measurements in a delay fear conditioning task with visual CS and electrical US" href="https://doi.org/10.5281/zenodo.3667714" target="_blank"><b>PsPM-VIS</b></a>
 	</td>
 	<td>
-		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: an index for human threat conditioning. Behavior Research Methods, 53, 1426-1439. " href="https://doi.org/10.3758/s13428-020-01490-5">Saccadic scanpath length: an index for human threat conditioning.</a>
+		<a title="Xia Y, Melinščak F, Bach DR (2020). Saccadic scanpath length: An index for human threat conditioning. Behavior Research Methods, 53:1426–1439." href="https://doi.org/10.3758/s13428-020-01490-5" target="_blank">Xia et al. (2020)</a>
 	</td>
-	<td>
-	</td>
+	<td></td>
+	<td style="text-align: center;">29</td>
 </tr>
 
 </tbody>


### PR DESCRIPTION
### Open Data page

- Add participant count (N) as a new column for each dataset.
- Shorten publication entries to "FirstAuthor et al. (Year)" to improve readability within the CMS table width constraints.
- Keep the full citation available via mouse-over (title attribute).
- Harmonize citation formatting across all entries to match the Publications page (surname + initials).

### News page

- Add news entries for recent PsPM-related publications (Xia, Liu et al., 2025; Bach, 2025; Liu et al., 2026; Gomes et al., 2026; Mancinelli & Bach, 2026).
- Add publication dates and DOI links.
- Note that the reward-conditioned HPR model from Xia, Liu et al. (2025) will be included in PsPM 7.1.


