### PR TITLE
Support segmented AcqKnowledge imports

### DIFF
--- a/src/pspm_get_acqmat.m
+++ b/src/pspm_get_acqmat.m
@@ -29,12 +29,21 @@ if isempty(settings)
   pspm_init;
 end
 sts = -1;
-sourceinfo = [];
+sourceinfo = struct();
 
 % load data
 % -------------------------------------------------------------------------
 inputdata = load(datafile);
 
+% store original recording offset
+sourceinfo.start_sample = inputdata.start_sample;
+sourceinfo.start_sample_unit = inputdata.isi_units;
+
+if inputdata.start_sample ~= 0
+  warning('ID:acqmat_nonzero_start', ...
+    'AcqKnowledge data starts at %g %s relative to the original recording.', ...
+    inputdata.start_sample, strtrim(inputdata.isi_units));
+end
 
 % extract individual channels
 % -------------------------------------------------------------------------
@@ -58,10 +67,6 @@ for k = 1:numel(import)
     import{k}.sr = 1000/inputdata.isi;
   else
     warning('\nUnsupported modality - please notify the developers.\n'); return;
-  end
-
-  if inputdata.start_sample ~= 0
-    warning('\nUnsupported sampling scheme - please notify the developers.\n'); return;
   end
 
   % get data & data units

--- a/test/pspm_get_acqmat_test.m
+++ b/test/pspm_get_acqmat_test.m
@@ -28,5 +28,35 @@ classdef pspm_get_acqmat_test < pspm_get_superclass
       import = this.assign_chantype_number(import);
       this.verifyWarning(@()pspm_get_acqmat(fn, import), 'ID:channel_not_contained_in_file');
     end
+    function nonzero_start_sample(this)
+    
+      inputdata = load('ImportTestData/acq/Acq_exported_SCR_Marker.mat');
+    
+      % Simulate AcqKnowledge export starting later in original recording
+      first_sample = 1001;
+      last_sample = min(2000, size(inputdata.data, 1));
+    
+      inputdata.data = inputdata.data(first_sample:last_sample, :);
+      inputdata.start_sample = inputdata.start_sample + ...
+        (first_sample - 1) * inputdata.isi;
+    
+      fn = [tempname '.mat'];
+      save(fn, '-struct', 'inputdata');
+      cleaner = onCleanup(@() delete(fn));
+    
+      import{1} = struct('type', 'scr', 'channel', 1);
+      import{2} = struct('type', 'marker', 'channel', 2);
+      import = this.assign_chantype_number(import);
+    
+      [sts, output, sourceinfo] = this.verifyWarning( ...
+        @() pspm_get_acqmat(fn, import), ...
+        'ID:acqmat_nonzero_start');
+    
+        this.verifyEqual(sts, 1);
+        this.verifyEqual(sourceinfo.start_sample, inputdata.start_sample);
+        this.verifyEqual(sourceinfo.start_sample_unit, inputdata.isi_units);
+        this.verifyEqual(output{1}.data, double(inputdata.data(:, 1)));
+    
+    end
   end
 end


### PR DESCRIPTION
Fixes #848 

## Changes proposed in this pull request:

Support segmented AcqKnowledge MAT imports with non-zero start_sample.

The import no longer aborts for non-zero start offsets. Instead, PsPM warns about the offset and stores start_sample together with its unit in sourceinfo.

 